### PR TITLE
Add arquivo docker-compose e .example.env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,5 @@
+POSTGRES_USER=exemplo_user
+POSTGRES_PASSWORD=exemplo-password-db
+POSTGRES_DB=exemplo_nome_db
+POSTGRES_PORT=5555
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:16
+    container_name: ContTrycatch_db
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - volume_TryCatch:/var/lib/postgresql/data
+    restart: always
+
+volumes:
+  volume_TryCatch:


### PR DESCRIPTION
Configurado o arquivo docker-compose para facilitar a criação do ambiente de teste com banco de dados Postgres para os desenvolvedores e configurado um exemplo do arquivo .env.