### PR TITLE
Feat/autenticacao rotas

### DIFF
--- a/src/app/api/skill/[id]/route.ts
+++ b/src/app/api/skill/[id]/route.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse, NextRequest } from 'next/server';
 import { getIdFromRequest } from '@/utils/url';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 export async function GET(request: NextRequest) {
   const id = getIdFromRequest(request);
@@ -27,6 +29,15 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem cadastrar skills.',
+      },
+      { status: 403 }
+    );
+  }
   const id = getIdFromRequest(request);
   const { name } = await request.json();
 
@@ -53,6 +64,15 @@ export async function PATCH(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem deletar skills.',
+      },
+      { status: 403 }
+    );
+  }
   const id = getIdFromRequest(request);
 
   try {

--- a/src/app/api/skill/route.ts
+++ b/src/app/api/skill/route.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 export async function GET() {
   try {
@@ -8,7 +10,7 @@ export async function GET() {
     });
     return NextResponse.json(skills);
   } catch (error) {
-    console.log(error)
+    console.log(error);
     return NextResponse.json(
       { error: 'Erro ao buscar skills.' },
       { status: 500 }
@@ -17,6 +19,15 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem cadastrar skills.',
+      },
+      { status: 403 }
+    );
+  }
   try {
     const { name } = await request.json();
 
@@ -33,7 +44,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json(skill, { status: 201 });
   } catch (error) {
-    console.log(error)
+    console.log(error);
     return NextResponse.json(
       { error: 'Erro ao criar skill.' },
       { status: 500 }

--- a/src/app/api/team-project/[id]/route.ts
+++ b/src/app/api/team-project/[id]/route.ts
@@ -1,9 +1,29 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse, NextRequest } from 'next/server';
 import { getIdFromRequest } from '@/utils/url';
+import jwt from 'jsonwebtoken';
+
+function getUserFromRequest(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader) return null;
+  const token = authHeader.split(' ')[1];
+  try {
+    return jwt.verify(token, process.env.JWT_SECRET as string) as {
+      id: string;
+    };
+  } catch {
+    return null;
+  }
+}
 
 export async function GET(request: NextRequest) {
   const id = getIdFromRequest(request);
+
+  const userAuth = getUserFromRequest(request);
+  if (!userAuth || userAuth.id !== id) {
+    return new Response('Acesso negado', { status: 403 });
+  }
+
   const project = await prisma.project.findUnique({
     where: { id },
     include: {
@@ -25,7 +45,13 @@ export async function GET(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   const id = getIdFromRequest(request);
+
+  const userAuth = getUserFromRequest(request);
+  if (!userAuth || userAuth.id !== id) {
+    return new Response('Acesso negado', { status: 403 });
+  }
   const data = await request.json();
+
   const { name, description, deadline, totalValue, status, skills, stacks } =
     data;
 
@@ -71,6 +97,12 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   const id = getIdFromRequest(request);
+
+  const userAuth = getUserFromRequest(request);
+  if (!userAuth || userAuth.id !== id) {
+    return new Response('Acesso negado', { status: 403 });
+  }
+
   const existing = await prisma.project.findUnique({
     where: { id },
   });

--- a/src/app/api/team-project/route.ts
+++ b/src/app/api/team-project/route.ts
@@ -1,7 +1,15 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
   const projects = await prisma.project.findMany({
     include: {
       owner: {
@@ -20,26 +28,17 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-  const data = await request.json();
-  const {
-    ownerId,
-    name,
-    description,
-    deadline,
-    totalValue,
-    status,
-    skills,
-    stacks,
-  } = data;
+  const session = await getServerSession(authOptions);
 
-  if (
-    !ownerId ||
-    !name ||
-    !description ||
-    !deadline ||
-    !totalValue ||
-    !status
-  ) {
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const data = await request.json();
+  const { name, description, deadline, totalValue, status, skills, stacks } =
+    data;
+
+  if (!name || !description || !deadline || !totalValue || !status) {
     return NextResponse.json(
       { error: 'Todos os campos obrigatórios devem ser preenchidos' },
       { status: 400 }
@@ -48,7 +47,7 @@ export async function POST(request: Request) {
 
   const project = await prisma.project.create({
     data: {
-      ownerId,
+      ownerId: session.user.id,
       name,
       description,
       deadline: new Date(deadline),

--- a/src/app/api/tech-stack/[id]/route.ts
+++ b/src/app/api/tech-stack/[id]/route.ts
@@ -1,9 +1,19 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse, NextRequest } from 'next/server';
 import { getIdFromRequest } from '@/utils/url';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
-// GET - Obter uma stack por ID
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem listar stacks.',
+      },
+      { status: 403 }
+    );
+  }
   const id = getIdFromRequest(request);
   try {
     const stack = await prisma.stack.findUnique({
@@ -27,8 +37,16 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// PATCH - Atualizar uma stack
 export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem alterar stacks.',
+      },
+      { status: 403 }
+    );
+  }
   const id = getIdFromRequest(request);
   try {
     const { name } = await request.json();
@@ -55,8 +73,16 @@ export async function PATCH(request: NextRequest) {
   }
 }
 
-// DELETE - Deletar uma stack
 export async function DELETE(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem deletar stacks.',
+      },
+      { status: 403 }
+    );
+  }
   const id = getIdFromRequest(request);
   try {
     await prisma.stack.delete({

--- a/src/app/api/tech-stack/[id]/route.ts
+++ b/src/app/api/tech-stack/[id]/route.ts
@@ -5,15 +5,6 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user.role !== 'ADMIN') {
-    return NextResponse.json(
-      {
-        error: 'Acesso negado. Apenas administradores podem listar stacks.',
-      },
-      { status: 403 }
-    );
-  }
   const id = getIdFromRequest(request);
   try {
     const stack = await prisma.stack.findUnique({

--- a/src/app/api/tech-stack/route.ts
+++ b/src/app/api/tech-stack/route.ts
@@ -1,15 +1,25 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
-// GET - Listar todas as stacks
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem listar stacks.',
+      },
+      { status: 403 }
+    );
+  }
   try {
     const stacks = await prisma.stack.findMany({
       orderBy: { name: 'asc' },
     });
     return NextResponse.json(stacks);
   } catch (error) {
-    console.log(error)
+    console.log(error);
     return NextResponse.json(
       { error: 'Erro ao buscar stacks.' },
       { status: 500 }
@@ -17,8 +27,16 @@ export async function GET() {
   }
 }
 
-// POST - Criar uma nova stack
 export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json(
+      {
+        error: 'Acesso negado. Apenas administradores podem cadastrar stacks.',
+      },
+      { status: 403 }
+    );
+  }
   try {
     const { name } = await request.json();
 
@@ -35,7 +53,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json(stack, { status: 201 });
   } catch (error) {
-    console.log(error)
+    console.log(error);
     return NextResponse.json(
       { error: 'Erro ao criar stack.' },
       { status: 500 }

--- a/src/app/api/tech-stack/route.ts
+++ b/src/app/api/tech-stack/route.ts
@@ -4,15 +4,6 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user.role !== 'ADMIN') {
-    return NextResponse.json(
-      {
-        error: 'Acesso negado. Apenas administradores podem listar stacks.',
-      },
-      { status: 403 }
-    );
-  }
   try {
     const stacks = await prisma.stack.findMany({
       orderBy: { name: 'asc' },

--- a/src/app/api/user/[id]/route.ts
+++ b/src/app/api/user/[id]/route.ts
@@ -89,7 +89,6 @@ export async function DELETE(request: NextRequest) {
   const id = getIdFromRequest(request);
 
   const userAuth = getUserFromRequest(request);
-
   if (!userAuth || userAuth.id !== id) {
     return new Response('Acesso negado', { status: 403 });
   }

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') {
     return NextResponse.json(
-      { error: 'Acesso negado. Apenas administradores podem criar convites.' },
+      { error: 'Acesso negado. Apenas administradores podem listar os usuários.' },
       { status: 403 }
     );
   }


### PR DESCRIPTION
Implementa proteção nas rotas da API de projetos, skills e stacks, permitindo apenas que usuários autenticados possam listar e criar projetos, e somente admin possa alterar e deletar skills e stacks. O ownerId agora é atribuído automaticamente com base no usuário logado via sessão (NextAuth). Refatora também a verificação de campos obrigatórios no POST.