### PR TITLE
feat(api): rotas stack taken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next-auth": "^4.24.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "zod": "^3.25.64"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -7675,6 +7676,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.64",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
+      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next-auth": "^4.24.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "zod": "^3.25.64"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/stack-taken/[id]/route.ts
+++ b/src/app/api/stack-taken/[id]/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+// Validação para edição de StackTaken
+const updateStackTakenSchema = z.object({
+  projectStackId: z.string().optional(),
+  stackId: z.string().optional(),
+});
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  try {
+    const stackTaken = await prisma.stackTaken.findUnique({
+      where: { id: params.id },
+      include: {
+        stack: true,
+        project: true,
+        projectStack: true,
+        user: true,
+      },
+    });
+
+    if (!stackTaken) {
+      return NextResponse.json(
+        { error: 'StackTaken não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(stackTaken);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao buscar StackTaken' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = updateStackTakenSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const existing = await prisma.stackTaken.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: 'StackTaken não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    if (existing.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: 'Ação não permitida' },
+        { status: 403 }
+      );
+    }
+
+    const updated = await prisma.stackTaken.update({
+      where: { id: params.id },
+      data: parsed.data,
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao atualizar StackTaken' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  try {
+    const existing = await prisma.stackTaken.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: 'StackTaken não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    if (existing.userId !== session.user.id) {
+      return NextResponse.json(
+        { error: 'Ação não permitida' },
+        { status: 403 }
+      );
+    }
+
+    await prisma.stackTaken.delete({
+      where: { id: params.id },
+    });
+
+    return NextResponse.json({ message: 'StackTaken removido com sucesso' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao remover StackTaken' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/stack-taken/route.ts
+++ b/src/app/api/stack-taken/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+// Validação com Zod - biblioteca TypeScript para validação de dados
+const createStackTakenSchema = z.object({
+  projectId: z.string(),
+  projectStackId: z.string(),
+  stackId: z.string(),
+});
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = createStackTakenSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, projectStackId, stackId } = parsed.data;
+
+  try {
+    const newStackTaken = await prisma.stackTaken.create({
+      data: {
+        userId: session.user.id,
+        projectId,
+        projectStackId,
+        stackId,
+      },
+    });
+
+    return NextResponse.json(newStackTaken, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao criar StackTaken' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const projectId = searchParams.get('projectId');
+
+  try {
+    const stackTakens = await prisma.stackTaken.findMany({
+      where: projectId ? { projectId } : { userId: session.user.id },
+      include: {
+        stack: true,
+        project: true,
+        projectStack: true,
+      },
+    });
+
+    return NextResponse.json(stackTakens);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao buscar StackTakens' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Criação da rota stack-taken (CRUD)
Implementados os endpoints REST para a entidade StackTaken:

POST e GET em api/stack-taken/route.ts

GET, PUT e DELETE em api/stack-taken/[id]/route.ts

Todas as rotas exigem autenticação via getServerSession, e o userId sempre é obtido da sessão — nunca enviado pelo frontend.

Adicionei validação dos dados com a biblioteca Zod, que garante que apenas os campos esperados (e no formato correto) sejam processados antes de qualquer operação com o banco.

As operações de PUT e DELETE só são permitidas se o StackTaken pertencer ao usuário autenticado.