### PR TITLE
feat(api): rotas ProjectStack

### DIFF
--- a/src/app/api/project-stack/[id]/route.ts
+++ b/src/app/api/project-stack/[id]/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+// Validação para atualização de percentage
+const updatePercentageSchema = z.object({
+  percentage: z.number().min(0).max(100),
+});
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  try {
+    const projectStack = await prisma.projectStack.findUnique({
+      where: { id: params.id },
+      include: {
+        stack: true,
+        project: true,
+      },
+    });
+
+    if (!projectStack) {
+      return NextResponse.json(
+        { error: 'ProjectStack não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(projectStack);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao buscar ProjectStack' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = updatePercentageSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const updated = await prisma.projectStack.update({
+      where: { id: params.id },
+      data: {
+        percentage: parsed.data.percentage,
+      },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao atualizar ProjectStack' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  try {
+    await prisma.projectStack.delete({
+      where: { id: params.id },
+    });
+
+    return NextResponse.json({ message: 'ProjectStack removido com sucesso' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao remover ProjectStack' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/project-stack/route.ts
+++ b/src/app/api/project-stack/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+// Validação de criação
+const createProjectStackSchema = z.object({
+  projectId: z.string(),
+  stackId: z.string(),
+  percentage: z.number().min(0).max(100),
+});
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = createProjectStackSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, stackId, percentage } = parsed.data;
+
+  try {
+    const newProjectStack = await prisma.projectStack.create({
+      data: {
+        projectId,
+        stackId,
+        percentage,
+      },
+    });
+
+    return NextResponse.json(newProjectStack, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao criar ProjectStack' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const projectId = searchParams.get('projectId');
+
+  if (!projectId) {
+    return NextResponse.json(
+      { error: 'projectId é obrigatório' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const stacks = await prisma.projectStack.findMany({
+      where: { projectId },
+      include: {
+        stack: true,
+      },
+    });
+
+    return NextResponse.json(stacks);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao buscar ProjectStacks' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Criação da rota project-stack (CRUD)
Endpoints implementados para a entidade ProjectStack:

POST e GET em api/project-stack/route.ts

GET, PUT, e DELETE em api/project-stack/[id]/route.ts

Todas as rotas exigem autenticação via getServerSession. No POST, validação para que o percentage esteja entre 0 e 100 usando Zod. No PUT, permitido atualizar apenas o campo percentage.

Incluí dados relacionados no GET, como stack e project, para facilitar o consumo no frontend.