### PR TITLE
feat(api): rotas ProjectSkill

### DIFF
--- a/src/app/api/project-skill/[id]/route.ts
+++ b/src/app/api/project-skill/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+// PUT: validação para trocar a skill associada ao projeto
+const updateProjectSkillSchema = z.object({
+  skillId: z.string(),
+});
+
+// GET /api/project-skill/[id]
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  try {
+    const projectSkill = await prisma.projectSkill.findUnique({
+      where: { id: params.id },
+      include: { skill: true },
+    });
+
+    if (!projectSkill) {
+      return NextResponse.json(
+        { error: 'Associação não encontrada' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(projectSkill);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao buscar associação' },
+      { status: 500 }
+    );
+  }
+}
+
+// PUT /api/project-skill/[id]
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = updateProjectSkillSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { skillId } = parsed.data;
+
+  try {
+    const existing = await prisma.projectSkill.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: 'Associação não encontrada' },
+        { status: 404 }
+      );
+    }
+
+    const updated = await prisma.projectSkill.update({
+      where: { id: params.id },
+      data: { skillId },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao atualizar skill do projeto' },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/project-skill/[id]
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  try {
+    await prisma.projectSkill.delete({
+      where: { id: params.id },
+    });
+
+    return NextResponse.json({
+      message: 'Skill removida do projeto com sucesso',
+    });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao remover skill' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/project-skill/route.ts
+++ b/src/app/api/project-skill/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+// Validação dos dados para criação
+const createProjectSkillSchema = z.object({
+  projectId: z.string(),
+  skillId: z.string(),
+});
+
+// POST /api/project-skill
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = createProjectSkillSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, skillId } = parsed.data;
+
+  try {
+    const exists = await prisma.projectSkill.findFirst({
+      where: { projectId, skillId },
+    });
+
+    if (exists) {
+      return NextResponse.json(
+        { error: 'Skill já associada ao projeto' },
+        { status: 400 }
+      );
+    }
+
+    const newProjectSkill = await prisma.projectSkill.create({
+      data: { projectId, skillId },
+    });
+
+    return NextResponse.json(newProjectSkill, { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao adicionar skill ao projeto' },
+      { status: 500 }
+    );
+  }
+}
+
+// GET /api/project-skill?projectId=<id>
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const projectId = searchParams.get('projectId');
+
+  if (!projectId) {
+    return NextResponse.json(
+      { error: 'projectId é obrigatório na query' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const skills = await prisma.projectSkill.findMany({
+      where: { projectId },
+      include: { skill: true },
+    });
+
+    return NextResponse.json(skills);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: 'Erro ao buscar skills do projeto' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
CRUD da rota project-skill
POST e GET em api/project-skill/route.ts

POST: associa uma skill a um projeto

GET: lista skills associadas a um projeto via query param projectId

GET, PUT, DELETE em api/project-skill/[id]/route.ts

GET: busca uma associação por ID

PUT: troca a skill associada (mantém o mesmo projeto)

DELETE: remove a skill do projeto

As rotas são protegidas por autenticação com getServerSession. Validações com Zod garantem dados válidos e previnem duplicações.