### PR TITLE
feat(api): rotas feedback, inclusão stackTakenId

### DIFF
--- a/prisma/migrations/20250616161930_add_stack_taken_to_feedback/migration.sql
+++ b/prisma/migrations/20250616161930_add_stack_taken_to_feedback/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Feedback" ADD COLUMN     "stackTakenId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Feedback" ADD CONSTRAINT "Feedback_stackTakenId_fkey" FOREIGN KEY ("stackTakenId") REFERENCES "StackTaken"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,7 @@ model StackTaken {
   stack          Stack        @relation("StackStacksTaken", fields: [stackId], references: [id])
   projectId      String
   project        Project      @relation("ProjectStacksTaken", fields: [projectId], references: [id])
+  feedbacks      Feedback[]
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 }
@@ -126,26 +127,28 @@ model ProjectSkill {
 }
 
 model Feedback {
-  id         String   @id @default(cuid())
-  projectId  String
-  project    Project  @relation(fields: [projectId], references: [id])
-  fromUserId String
-  fromUser   User     @relation("FeedbackGiver", fields: [fromUserId], references: [id])
-  toUserId   String
-  toUser     User     @relation("FeedbackReceiver", fields: [toUserId], references: [id])
-  rating     Int
-  comment    String?
-  anonymous  Boolean
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id           String      @id @default(cuid())
+  projectId    String
+  project      Project     @relation(fields: [projectId], references: [id])
+  fromUserId   String
+  fromUser     User        @relation("FeedbackGiver", fields: [fromUserId], references: [id])
+  toUserId     String
+  toUser       User        @relation("FeedbackReceiver", fields: [toUserId], references: [id])
+  stackTakenId String?
+  stackTaken   StackTaken? @relation(fields: [stackTakenId], references: [id])
+  rating       Int
+  comment      String?
+  anonymous    Boolean
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
 }
 
 model Invite {
-  id        String   @id @default(cuid())
-  email     String   // Email do convidado
-  code      String   // Código do convite (pode ser gerado aleatoriamente)
-  used      Boolean  @default(false)
-  invitedBy String?  // ID do usuário que enviou o convite (opcional)
-  createdAt DateTime @default(now())
+  id        String    @id @default(cuid())
+  email     String // Email do convidado
+  code      String // Código do convite (pode ser gerado aleatoriamente)
+  used      Boolean   @default(false)
+  invitedBy String? // ID do usuário que enviou o convite (opcional)
+  createdAt DateTime  @default(now())
   usedAt    DateTime?
 }

--- a/src/app/api/feedback/[id]/route.ts
+++ b/src/app/api/feedback/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+export async function GET(_: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const feedbackId = params.id;
+
+  try {
+    const feedback = await prisma.feedback.findUnique({
+      where: { id: feedbackId },
+      include: {
+        fromUser: true,
+        toUser: true,
+        stackTaken: {
+          include: {
+            stack: true,
+            project: true,
+          },
+        },
+      },
+    });
+
+    if (!feedback) {
+      return NextResponse.json(
+        { error: 'Feedback não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(feedback);
+  } catch (error) {
+    console.error('Erro ao buscar feedback:', error);
+    return NextResponse.json({ error: 'Erro interno' }, { status: 500 });
+  }
+}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const feedbackSchema = z.object({
+  projectId: z.string(),
+  toUserId: z.string(),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().optional(),
+  anonymous: z.boolean(),
+  stackTakenId: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = feedbackSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Dados inválidos', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, toUserId, rating, comment, anonymous, stackTakenId } =
+    parsed.data;
+  const fromUserId = session.user.id;
+
+  if (fromUserId === toUserId) {
+    return NextResponse.json(
+      { error: 'Você não pode avaliar a si mesmo.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const feedback = await prisma.feedback.create({
+      data: {
+        projectId,
+        fromUserId,
+        toUserId,
+        rating,
+        comment,
+        anonymous,
+        stackTakenId,
+      },
+    });
+
+    return NextResponse.json(feedback, { status: 201 });
+  } catch (error) {
+    console.error('Erro ao criar feedback:', error);
+    return NextResponse.json(
+      { error: 'Erro interno ao criar feedback' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const projectId = searchParams.get('projectId');
+
+  if (!projectId) {
+    return NextResponse.json(
+      { error: 'Parâmetro projectId é obrigatório' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const feedbacks = await prisma.feedback.findMany({
+      where: { projectId },
+      include: {
+        fromUser: true,
+        toUser: true,
+        stackTaken: {
+          include: {
+            stack: true,
+            project: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json(feedbacks);
+  } catch (error) {
+    console.error('Erro ao buscar feedbacks:', error);
+    return NextResponse.json(
+      { error: 'Erro interno ao buscar feedbacks' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
mplementado o CRUD básico da entidade Feedback, seguindo as regras de segurança e estrutura REST do projeto.

O que foi feito:
Criadas as rotas em:

api/feedback/route.ts → POST (criar feedback), GET (listar todos por projeto)

api/feedback/[id]/route.ts → GET (único feedback)

O userId do autor da avaliação (fromUserId) é extraído da sessão com getServerSession, impedindo que o usuário envie manualmente esse dado.

A avaliação não pode ser feita para si mesmo (fromUserId !== toUserId) e não pode ser editada nem excluída.

Foi adicionada a opção de avaliação anônima (anonymous: true/false) que controla apenas a exibição no frontend, mas o autor é sempre registrado no banco por segurança.

A avaliação é feita com uma pontuação (rating) e comentário opcional (comment).

Incluído relacionamento com StackTaken para vincular o feedback à stack que o usuário executou no projeto.

Alterações no schema.prisma:
O modelo Feedback foi atualizado para incluir:

prisma
Copiar
Editar
stackTakenId   String?
stackTaken     StackTaken?  @relation(fields: [stackTakenId], references: [id])
E o modelo StackTaken recebeu o campo reverso obrigatório:

prisma
Copiar
Editar
feedbacks      Feedback[]
Essa alteração foi necessária pois o Prisma exige que ambos os lados de uma relação sejam declarados para garantir a integridade e o uso completo dos relacionamentos nos queries (include, select, etc).