### PR TITLE
refactor(api-team-project): padroniza autenticação e validações no te…

### DIFF
--- a/src/app/api/team-project/[id]/route.ts
+++ b/src/app/api/team-project/[id]/route.ts
@@ -1,35 +1,48 @@
 import { prisma } from '@/lib/prisma';
-import { NextResponse, NextRequest } from 'next/server';
-import { getIdFromRequest } from '@/utils/url';
-import jwt from 'jsonwebtoken';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+import { checkAuth } from '@/lib/check-auth';
+import { z } from 'zod';
 
+const idSchema = z.string().min(25, 'ID inválido').max(36, 'ID inválido');
+const updateProjectSchema = z.object({
+  name: z.string().min(1, 'O nome é obrigatório.'),
+  description: z.string().min(1, 'A descrição é obrigatória.'),
+  deadline: z
+    .string()
+    .refine((val) => !isNaN(Date.parse(val)), { message: 'Data inválida.' }),
+  totalValue: z.number({
+    invalid_type_error: 'Valor total deve ser um número.',
+  }),
+  status: z.enum(['BUSCANDO', 'EM_ANDAMENTO', 'COMPLETO']),
+  skills: z.array(z.string().uuid('ID da skill inválido')).optional(),
+  stacks: z
+    .array(
+      z.object({
+        stackId: z.string().uuid('ID da stack inválido'),
+        percentage: z.number().min(0).max(100),
+      })
+    )
+    .optional(),
+});
 
-function getUserFromRequest(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader) return null;
-  const token = authHeader.split(' ')[1];
-  try {
-    return jwt.verify(token, process.env.JWT_SECRET as string) as {
-      id: string;
-    };
-  } catch {
-    return null;
+export async function GET(
+  request: Request,
+  context: { params: { id: string } }
+) {
+  const { authorized, response, session } = await checkAuth({
+    allowedRoles: ['ADMIN', 'USER'],
+  });
+  if (!authorized || !session) return response;
+
+  const idParse = idSchema.safeParse(context.params.id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'ID inválido' }, { status: 400 });
   }
-}
+  const projectId = idParse.data;
 
-export async function GET(request: NextRequest) {
   try {
-    const id = getIdFromRequest(request);
-
-    const userAuth = getUserFromRequest(request);
-    if (!userAuth || userAuth.id !== id) {
-      return new Response('Acesso negado', { status: 403 });
-    }
-
     const project = await prisma.project.findUnique({
-      where: { id },
+      where: { id: projectId },
       include: {
         owner: { select: { id: true, name: true, avatar: true } },
         skills: { include: { skill: true } },
@@ -44,6 +57,10 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    if (project.ownerId !== session.user.id && session.user.role !== 'ADMIN') {
+      return NextResponse.json({ error: 'Acesso negado' }, { status: 403 });
+    }
+
     return NextResponse.json(project);
   } catch (error) {
     console.error('Erro ao buscar projeto:', error);
@@ -54,28 +71,50 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function PUT(request: Request, context: { params: { id: string } }) {
-  let session;
+export async function PUT(
+  request: Request,
+  context: { params: { id: string } }
+) {
+  const { authorized, response, session } = await checkAuth({
+    allowedRoles: ['ADMIN', 'USER'],
+  });
+  if (!authorized || !session) return response;
 
-  try {
-    session = await getServerSession(authOptions);
-  } catch (error) {
-    console.error('Erro ao obter sessão:', error);
-    return NextResponse.json(
-      { error: 'Erro de autenticação' },
-      { status: 500 }
-    );
+  const idParse = idSchema.safeParse(context.params.id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'ID inválido' }, { status: 400 });
   }
 
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  const projectId = idParse.data;
+
+  const body = await request.json();
+  const parse = updateProjectSchema.safeParse(body);
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.format() }, { status: 400 });
   }
 
-  const { id: projectId } = await context.params;
-  const data = await request.json();
-  const { name, description, deadline, totalValue, status, skills, stacks } = data;
-
   try {
+    const existing = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: 'Projeto não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    if (existing.ownerId !== session.user.id && session.user.role !== 'ADMIN') {
+      return NextResponse.json(
+        { error: 'Você não tem permissão para editar este projeto.' },
+        { status: 403 }
+      );
+    }
+
+    const { name, description, deadline, totalValue, status, skills, stacks } =
+      parse.data;
+
     const updated = await prisma.project.update({
       where: { id: projectId },
       data: {
@@ -109,16 +148,23 @@ export async function PUT(request: Request, context: { params: { id: string } })
   }
 }
 
-export async function DELETE(request: Request, context: { params: { id: string } }) {
+export async function DELETE(
+  request: Request,
+  context: { params: { id: string } }
+) {
+  const { authorized, response, session } = await checkAuth({
+    allowedRoles: ['ADMIN', 'USER'],
+  });
+  if (!authorized || !session) return response;
+
+  const idParse = idSchema.safeParse(context.params.id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'ID inválido' }, { status: 400 });
+  }
+
+  const projectId = idParse.data;
+
   try {
-    const { id: projectId } = await context.params;
-
-   
-    const session = await getServerSession(authOptions);
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
-    }
-
     const existing = await prisma.project.findUnique({
       where: { id: projectId },
     });
@@ -130,22 +176,15 @@ export async function DELETE(request: Request, context: { params: { id: string }
       );
     }
 
-    if (existing.ownerId !== session.user.id) {
+    if (existing.ownerId !== session.user.id && session.user.role !== 'ADMIN') {
       return NextResponse.json(
-      { error: 'Você não tem permissão para deletar este projeto.' },
-      { status: 403 }
-    );
+        { error: 'Você não tem permissão para deletar este projeto.' },
+        { status: 403 }
+      );
     }
-
-    await prisma.projectSkill.deleteMany({
-      where: { projectId },
-    });
-    await prisma.projectStack.deleteMany({
-      where: { projectId },
-    });
-    await prisma.project.delete({
-      where: { id: projectId },
-    });
+    await prisma.projectSkill.deleteMany({ where: { projectId } });
+    await prisma.projectStack.deleteMany({ where: { projectId } });
+    await prisma.project.delete({ where: { id: projectId } });
 
     return NextResponse.json({ message: 'Projeto deletado com sucesso' });
   } catch (error) {

--- a/src/app/api/team-project/route.ts
+++ b/src/app/api/team-project/route.ts
@@ -2,6 +2,29 @@ import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
 import { checkAuth } from '@/lib/check-auth';
 
+import { z } from 'zod';
+
+const createProjectSchema = z.object({
+  name: z.string().min(1, 'O nome é obrigatório'),
+  description: z.string().min(1, 'A descrição é obrigatória'),
+  deadline: z
+    .string()
+    .refine((val) => !isNaN(Date.parse(val)), 'Data inválida'),
+  totalValue: z
+    .number()
+    .nonnegative('O valor total deve ser um número positivo'),
+  status: z.enum(['BUSCANDO', 'EM_ANDAMENTO', 'COMPLETO']),
+  skills: z.array(z.string().uuid()).optional(),
+  stacks: z
+    .array(
+      z.object({
+        stackId: z.string().uuid(),
+        percentage: z.number().min(0).max(100),
+      })
+    )
+    .optional(),
+});
+
 export async function GET() {
   const { authorized, response } = await checkAuth({
     allowedRoles: ['ADMIN', 'USER'],
@@ -31,17 +54,15 @@ export async function POST(request: Request) {
   });
   if (!authorized || !session) return response;
 
-  const data = await request.json();
-  const { name, description, deadline, totalValue, status, skills, stacks } =
-    data;
+  const body = await request.json();
+  const parse = createProjectSchema.safeParse(body);
 
-  if (!name || !description || !deadline || !totalValue || !status) {
-    return NextResponse.json(
-      { error: 'Todos os campos obrigatórios devem ser preenchidos' },
-      { status: 400 }
-    );
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.format() }, { status: 400 });
   }
 
+  const { name, description, deadline, totalValue, status, skills, stacks } =
+    parse.data;
   const project = await prisma.project.create({
     data: {
       ownerId: session.user.id,


### PR DESCRIPTION
Endpoints GET, PUT e DELETE da API team-project padronizados, uso do checkAuth em vez de getServerSession, validações com Zod para o id e o corpo da requisição no PUT. Permissões para garantir que apenas o dono do projeto ou administradores possam editar ou deletar, enquanto o GET permite acesso a qualquer usuário autenticado. #132 team-project