### PR TITLE
feat(api-tech-stack): checkAuth, impede nome duplicado e se vinculado…

### DIFF
--- a/src/app/api/tech-stack/[id]/route.ts
+++ b/src/app/api/tech-stack/[id]/route.ts
@@ -1,12 +1,22 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse, NextRequest } from 'next/server';
 import { getIdFromRequest } from '@/utils/url';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { checkAuth } from '@/lib/check-auth';
+import { z } from 'zod';
 
+const idSchema = z.string().min(1, 'ID inválido.');
+const updateTechStackSchema = z.object({
+  name: z.string().min(1, 'O nome é obrigatório.'),
+  forceUpdate: z.boolean().optional(),
+});
 
 export async function GET(request: NextRequest) {
   const id = getIdFromRequest(request);
+
+  const idParse = idSchema.safeParse(id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'ID inválido.' }, { status: 400 });
+  }
 
   try {
     const stack = await prisma.stack.findUnique({
@@ -31,25 +41,50 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PATCH(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const auth = await checkAuth({ requireAdmin: true });
+  if (!auth.authorized) return auth.response;
 
-  if (!session || session.user.role !== 'ADMIN') {
-    return NextResponse.json(
-      {
-        error: 'Acesso negado. Apenas administradores podem alterar stacks.',
-      },
-      { status: 403 }
-    );
-  }
   const id = getIdFromRequest(request);
 
-  try {
-    const { name } = await request.json();
+  const idParse = idSchema.safeParse(id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'ID inválido.' }, { status: 400 });
+  }
 
-    if (!name) {
+  const body = await request.json();
+  const parse = updateTechStackSchema.safeParse(body);
+
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.format() }, { status: 400 });
+  }
+
+  const { name, forceUpdate } = parse.data;
+
+  try {
+    const existing = await prisma.stack.findFirst({
+      where: {
+        name,
+        NOT: { id }, // ignora a própria stack que está sendo atualizada
+      },
+    });
+
+    if (existing) {
       return NextResponse.json(
-        { error: 'O nome é obrigatório.' },
-        { status: 400 }
+        { error: 'Já existe uma stack com esse nome.' },
+        { status: 409 }
+      );
+    }
+
+    const linkedStack = await prisma.projectStack.findFirst({
+      where: { stackId: id },
+    });
+    if (linkedStack && !forceUpdate) {
+      return NextResponse.json(
+        {
+          error:
+            'Esta stack está sendo usada em projetos. Alterações podem impactar dados existentes.',
+        },
+        { status: 409 }
       );
     }
 
@@ -61,6 +96,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json(stack);
   } catch (error) {
     console.log(error);
+    console.error('Erro ao atualizar stack:', error);
     return NextResponse.json(
       { error: 'Erro ao atualizar stack.' },
       { status: 500 }
@@ -69,19 +105,28 @@ export async function PATCH(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const auth = await checkAuth({ requireAdmin: true });
+  if (!auth.authorized) return auth.response;
 
-  if (!session || session.user.role !== 'ADMIN') {
-    return NextResponse.json(
-      {
-        error: 'Acesso negado. Apenas administradores podem deletar stacks.',
-      },
-      { status: 403 }
-    );
-  }
   const id = getIdFromRequest(request);
-  
+
+  const idParse = idSchema.safeParse(id);
+  if (!idParse.success) {
+    return NextResponse.json({ error: 'ID inválido.' }, { status: 400 });
+  }
+
   try {
+    const projectStack = await prisma.projectStack.findFirst({
+      where: { stackId: id },
+    });
+
+    if (projectStack) {
+      return NextResponse.json(
+        { error: 'Não é possível deletar uma stack que está em uso.' },
+        { status: 400 }
+      );
+    }
+
     await prisma.stack.delete({
       where: { id },
     });

--- a/src/app/api/tech-stack/route.ts
+++ b/src/app/api/tech-stack/route.ts
@@ -1,7 +1,11 @@
 import { prisma } from '@/lib/prisma';
 import { NextResponse, NextRequest } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { checkAuth } from '@/lib/check-auth';
+import { z } from 'zod';
+
+const createStackSchema = z.object({
+  name: z.string().min(1, 'O nome da stack é obrigatório.'),
+});
 
 export async function GET() {
   try {
@@ -19,22 +23,26 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session || session.user.role !== 'ADMIN') {
-    return NextResponse.json(
-      {
-        error: 'Acesso negado. Apenas administradores podem cadastrar stacks.',
-      },
-      { status: 403 }
-    );
-  }
-  try {
-    const { name } = await request.json();
+  const auth = await checkAuth({ requireAdmin: true });
+  if (!auth.authorized) return auth.response;
 
-    if (!name) {
+  try {
+    const body = await request.json();
+    const parse = createStackSchema.safeParse(body);
+
+    if (!parse.success) {
       return NextResponse.json(
-        { error: 'O nome da stack é obrigatório.' },
+        { error: parse.error.format() },
         { status: 400 }
+      );
+    }
+
+    const { name } = parse.data;
+    const existingStack = await prisma.stack.findUnique({ where: { name } });
+    if (existingStack) {
+      return NextResponse.json(
+        { error: 'Já existe uma stack com esse nome.' },
+        { status: 409 }
       );
     }
 
@@ -44,7 +52,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(stack, { status: 201 });
   } catch (error) {
-    console.log(error);
+    console.error('Erro ao criar stack:', error);
     return NextResponse.json(
       { error: 'Erro ao criar stack.' },
       { status: 500 }


### PR DESCRIPTION
Aplicado checkAuth para restringir PATCH e DELETE a ADMIN.

Validação para impedir nome duplicado na edição.

Aviso ao tentar alterar stack vinculada a projetos (sem bloqueio, com opção de forceUpdate).

Bloqueio de deleção se a stack estiver em uso.

Padronização das mensagens de erro.

BREAKING CHANGE: A API tech-stack agora retorna aviso se a stack estiver em uso. Frontend precisa tratar resposta 409 e permitir confirmação com forceUpdate @FernandaBarrosLinhares 

feat #141