### PR TITLE
fix(api-invite): validação duplicidade email rota invite em POST e PATCH

### DIFF
--- a/src/app/api/invite/[id]/route.ts
+++ b/src/app/api/invite/[id]/route.ts
@@ -70,7 +70,9 @@ export async function PATCH(request: NextRequest) {
       },
     });
 
-    if (existing) {
+    const userExisting = await prisma.user.findFirst({ where: { email } });
+
+    if (existing || userExisting) {
       return buildResponse({
         success: false,
         message: MESSAGES.INVITE.ALREADY_EXISTS,

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -51,8 +51,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const existing = await prisma.invite.findFirst({ where: { email } });
+    const userExisting = await prisma.user.findFirst({ where: { email } });
 
-    if (existing) {
+    if (existing || userExisting) {
       return buildResponse({
         success: false,
         message: MESSAGES.INVITE.ALREADY_EXISTS,

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -44,7 +44,7 @@ export const MESSAGES = {
   INVITE: {
     NOT_FOUND: 'Convite não encontrado.',
     VALID: 'Convite válido.',
-    ALREADY_EXISTS: 'Já existe um convite com este email.',
+    ALREADY_EXISTS: 'Já existe um convite ou usuário com este email.',
     INTERNAL_DELETE_ERROR: 'Erro interno ao excluir convite.',
     INTERNAL_ERROR: 'Erro interno ao processar convite.',
     FETCH_SUCCESS: 'Convites carregados com sucesso.',


### PR DESCRIPTION
fix #257
validação se existe o email na tabela user, não aceita cadastro duplicado em POST e PATCH

<img width="458" height="415" alt="Image" src="https://github.com/user-attachments/assets/e01dd9a4-da16-4b55-b94a-3b32f70753fd" />

<img width="513" height="264" alt="Image" src="https://github.com/user-attachments/assets/853ee970-c4ad-4fb4-8bc0-9af258ebb75f" />
