### PR TITLE
fix(projectstackselector): quando clicar no campo percentual, o 0 some

### DIFF
--- a/src/components/Dashboard/TeamProject/ProjectStackSelector.tsx
+++ b/src/components/Dashboard/TeamProject/ProjectStackSelector.tsx
@@ -119,6 +119,19 @@ export function ProjectStackSelector() {
               <Input
                 type="number"
                 value={stack.percentage}
+                onFocus={(e) => {
+                  if (e.target.value === '0') {
+                    e.target.value = ''; // limpa o campo quando o valor é 0
+                  }
+                }}
+                onBlur={(e) => {
+                  if (e.target.value === '') {
+                    // se o usuário não digitar nada, volta o 0
+                    const newStacks = [...stacks];
+                    newStacks[index].percentage = 0;
+                    setValue('stacks', newStacks);
+                  }
+                }}
                 onChange={(e) => {
                   const newStacks = [...stacks];
                   newStacks[index].percentage = Number(e.target.value);


### PR DESCRIPTION
fix #308

Utilizei os eventos onFocus e onBlur do input

<img width="878" height="254" alt="Image" src="https://github.com/user-attachments/assets/b78b704b-56d3-491c-98b9-40f9532d00a5" />

<img width="853" height="216" alt="Image" src="https://github.com/user-attachments/assets/d5b5bcad-db28-44bf-bd36-071b8e9abc14" />
