### PR TITLE
feat(api-skill): POST Skill preenchimento automático da url do icone,…

### DIFF
--- a/src/app/api/skill/route.ts
+++ b/src/app/api/skill/route.ts
@@ -44,7 +44,22 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const { name, iconUrl } = parse.data;
+    const { name } = parse.data;
+    const normalizedName = name.trim().toLowerCase();
+
+    const iconUrl = `https://cdn.jsdelivr.net/gh/devicons/devicon/icons/${normalizedName}/${normalizedName}-original.svg`;
+
+    // Verifica se o ícone realmente existe
+    const response = await fetch(iconUrl);
+    if (!response.ok) {
+      return buildResponse({
+        success: false,
+        message: 'Ícone não encontrado no repositório Devicon.',
+        status: 400,
+      });
+    }
+
+    // Verifica se já existe uma skill com esse nome
     const existingSkill = await prisma.skill.findUnique({ where: { name } });
     if (existingSkill) {
       return buildResponse({


### PR DESCRIPTION
… utilizando o nome da skill

feat #322

Cadastro de nova skill foi alterado para preenchimento automático da url do icone, utilizando o nome da skill

<img width="1140" height="479" alt="Image" src="https://github.com/user-attachments/assets/791b3ca3-598c-4126-8fea-81f2cb99cad5" />