### PR TITLE
feat(component-skill-form): skillForm ajustado para enviar somente o …

### DIFF
--- a/src/components/Dashboard/Skill/SkillForm.tsx
+++ b/src/components/Dashboard/Skill/SkillForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -12,6 +12,17 @@ export function SkillForm() {
   const [iconUrl, setIconUrl] = useState('');
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    if (!name.trim()) {
+      setIconUrl('');
+      return;
+    }
+
+    const normalized = name.trim().toLowerCase();
+    const url = `https://cdn.jsdelivr.net/gh/devicons/devicon/icons/${normalized}/${normalized}-original.svg`;
+    setIconUrl(url);
+  }, [name]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -20,7 +31,7 @@ export function SkillForm() {
       const response = await fetch('/api/skill', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, iconUrl }),
+        body: JSON.stringify({ name }),
       });
 
       const data = await response.json();
@@ -59,25 +70,13 @@ export function SkillForm() {
             />
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="skill-icon">Icone da Skill</Label>
-            <Input
-              id="skill-icon"
-              type="url"
-              value={iconUrl}
-              onChange={(e) => setIconUrl(e.target.value)}
-              placeholder="Ex: https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg"
-              required
-            />
-          </div>
-
           {/* Pré-visualização do ícone */}
           {iconUrl && (
             <div className="flex flex-col items-center space-y-2">
               <p className="text-sm text-gray-500">Pré-visualização:</p>
               <img
                 src={iconUrl}
-                alt="Prévia do ícone"
+                alt={`Ícone da skill ${name}`}
                 className="h-12 w-12 object-contain"
                 onError={(e) => {
                   (e.currentTarget as HTMLImageElement).src =
@@ -86,6 +85,7 @@ export function SkillForm() {
               />
             </div>
           )}
+
           <Button type="submit" disabled={loading} className="w-full">
             {loading ? 'Enviando...' : 'Cadastrar Skill'}
           </Button>


### PR DESCRIPTION
…nome da skill para o backend

Componente SkillForm ajustado para enviar somente o nome da skill para o backend, mantendo a visualização do icone da skill

<img width="329" height="408" alt="Image" src="https://github.com/user-attachments/assets/4f58eda5-532a-4766-bf58-47015c0dc0c9" />