### PR TITLE
feat(link-admin-navbar): link admin-page adicionado ao componente Navbar

### DIFF
--- a/src/components/layout/Navbar/Navbar.tsx
+++ b/src/components/layout/Navbar/Navbar.tsx
@@ -18,6 +18,7 @@ import {
   ChevronLeft,
   FolderKanban,
   MessageCircleQuestion,
+  UserRoundCog,
 } from 'lucide-react';
 
 export function Navbar() {
@@ -136,6 +137,20 @@ export function Navbar() {
                 </span>
               </Link>
             </li>
+            {/* Admin Page */}
+            {user?.role === 'ADMIN' && (
+              <li>
+                <Link
+                  href="/dashboard/admin-page"
+                  className={`flex items-center gap-2 ${isSidebarOpen ? 'justify-start' : 'justify-center'} ${pathname === '/dashboard/admin-page' ? 'rounded-sm bg-[#3B38A0] p-2 text-gray-50' : 'bg-transparent'} `}
+                >
+                  <UserRoundCog size={20} />
+                  <span className={`${isSidebarOpen ? 'block' : 'hidden'}`}>
+                    Admin Page
+                  </span>
+                </Link>
+              </li>
+            )}
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
Link admin-page adicionado ao componente Navbar, exibido somente se o usuário logado for role ADMIN

<img width="237" height="539" alt="Image" src="https://github.com/user-attachments/assets/fb72ea5c-7d69-431a-bbe3-bfeb5ebf5b66" />


feat #412