### PR TITLE
refactor(/home): ajusta algumas seções do home para melhor layout

### DIFF
--- a/src/components/layout/Home/AboutUs.tsx
+++ b/src/components/layout/Home/AboutUs.tsx
@@ -8,8 +8,8 @@ export default function AboutUs() {
       id="aboutUs"
       className="mt-12 md:mt-20 lg:mt-15 xl:mt-26 xxl:mt-32"
     >
-      <div className="flex flex-col lg:grid lg:grid-cols-12 lg:grid-rows-2">
-        <h2 className="mt-4 text-[26px] leading-[120%] font-medium text-[#35343C] md:text-[44px] lg:col-start-2 lg:col-end-7 lg:row-start-2 xxl:text-[64px]">
+      <div className="flex flex-col lg:grid lg:grid-cols-12">
+        <h2 className="mt-4 text-[26px] leading-[120%] font-medium text-[#35343C] md:text-[44px] lg:col-start-2 lg:col-end-7 xxl:text-[64px]">
           Sobre nossa rede
           <span className="flex items-center">
             <Image
@@ -23,7 +23,7 @@ export default function AboutUs() {
             colaborativa
           </span>
         </h2>
-        <p className="mt-[18px] text-[14px] leading-[140%] text-[#5C5C65] md:w-[496px] md:text-[16px] lg:col-start-8 lg:col-end-12 lg:row-start-2 lg:w-full xl:col-start-9 xxl:ml-20 xxl:w-[368px] xxl:text-[18px]">
+        <p className="mt-[18px] text-[14px] leading-[140%] text-[#5C5C65] md:w-[496px] md:text-[16px] lg:col-start-7 lg:col-end-12 lg:ml-4 lg:w-full xxl:ml-5 xxl:w-auto xxl:text-2xl">
           Conectamos talentos a projetos reais em um ambiente colaborativo, com
           aprendizado prático e troca de conhecimento entre diferentes níveis de
           experiência.
@@ -86,8 +86,8 @@ export default function AboutUs() {
           href="about/#entrega"
           className="flex w-full flex-col rounded-2xl bg-[#D9D9ED] p-5 md:p-[23px] lg:col-start-7 lg:col-end-12 lg:p-7"
         >
-          <div className="flex items-end justify-between">
-            <p className="h-12 w-[175px] text-[24px] leading-6 font-medium text-[#3B38A0] md:w-48 md:text-[26px] lg:h-16 lg:w-[233px] lg:text-[32px] lg:leading-8 xl:w-[262px] xl:text-[36px] xxl:h-[104px] xxl:w-[379px] xxl:text-[52px] xxl:leading-12">
+          <div className="flex items-end justify-between md:items-center">
+            <p className="h-12 w-[175px] text-[24px] leading-6 font-medium text-[#3B38A0] md:w-auto md:text-[32px] md:leading-normal lg:h-16 lg:w-[233px] lg:text-[32px] lg:leading-9 xl:w-[262px] xl:text-[36px] xl:lg:leading-10 xxl:h-[104px] xxl:w-[379px] xxl:text-[52px] xxl:leading-12">
               Da ideia até a entrega final
             </p>
             <SquarePen className="h-7 w-7 text-[#3B38A0] lg:h-[34px] lg:w-[34px] xl:h-10 xl:w-10 xxl:h-14 xxl:w-14" />
@@ -95,7 +95,7 @@ export default function AboutUs() {
         </Link>
 
         {/* Card nossa proposta */}
-        <div className="w-full overflow-hidden rounded-2xl bg-[#A1A0D1] md:grid md:grid-cols-2 lg:col-start-2 lg:col-end-12 lg:rounded-[28px]">
+        <div className="w-full overflow-hidden rounded-2xl bg-[#A1A0D1] lg:col-start-2 lg:col-end-12 lg:grid lg:grid-cols-2 lg:rounded-[28px]">
           {/* TEXTO */}
           <div className="flex flex-col justify-center gap-3 p-6 md:p-8 xl:p-[34px] xxl:p-[77px]">
             <p className="text-[12px] font-medium text-white md:text-[14px] xxl:text-[16px]">
@@ -114,7 +114,7 @@ export default function AboutUs() {
           </div>
 
           {/* IMAGEM */}
-          <div className="hidden md:block md:h-full md:w-full md:bg-[url('/BgNossaProposta.svg')] md:bg-cover md:bg-right md:bg-no-repeat" />
+          <div className="hidden lg:block lg:h-full lg:w-full lg:bg-[url('/BgNossaProposta.svg')] lg:bg-cover lg:bg-right lg:bg-no-repeat" />
         </div>
       </div>
     </section>

--- a/src/components/layout/Home/Faq.tsx
+++ b/src/components/layout/Home/Faq.tsx
@@ -57,7 +57,7 @@ export default function FAQ() {
       {/* MOBILE + TABLET */}
       <div className="block lg:hidden">
         {/* Bloco superior */}
-        <div className="relative mt-10 flex h-[204px] flex-col justify-between rounded-2xl bg-[#35343C] px-6 py-8 md:mt-16">
+        <div className="relative mt-10 flex h-auto flex-col justify-between rounded-2xl bg-[#35343C] px-6 py-8 md:mt-16">
           <div className="flex">
             <p className="text-[14px] leading-[140%] font-medium text-[#D9D9ED] md:text-[16px]">
               {perguntas[ativo].pergunta}
@@ -65,7 +65,7 @@ export default function FAQ() {
             <MoveUp className="h-5! w-5! stroke-3 text-[#D9D9ED]" />
           </div>
 
-          <p className="mt-4 text-[14px] leading-[140%] text-white md:text-[16px]">
+          <p className="mt-4 text-[14px] text-white md:text-[16px]">
             {perguntas[ativo].resposta}
           </p>
 
@@ -108,12 +108,12 @@ export default function FAQ() {
         <div className="mt-10 grid grid-cols-12 items-stretch gap-4">
           {/* Coluna esquerda – lista completa */}
           <div className="col-start-2 col-end-7">
-            <div className="flex h-full flex-col gap-4">
+            <div className="flex h-full flex-col justify-evenly gap-4">
               {perguntas.map((item, index) => (
                 <div
                   key={index}
                   onClick={() => setAtivo(index)}
-                  className={`flex h-auto cursor-pointer items-center justify-between rounded-[20px] px-6 py-5 transition-colors xxl:h-[104px] ${
+                  className={`flex h-full cursor-pointer items-center justify-between rounded-[20px] px-6 py-5 transition-colors xxl:h-[104px] ${
                     ativo === index ? 'bg-[#35343C] text-white' : 'bg-[#D9D9ED]'
                   }`}
                 >
@@ -144,7 +144,7 @@ export default function FAQ() {
               />
 
               {/* ZONA SEGURA DO TEXTO */}
-              <div className="-full mx-auto flex max-w-[80%] items-center px-6 py-12 xl:py-14 xxl:py-16">
+              <div className="mx-auto flex h-auto max-w-[80%] items-center px-6 py-12 xl:py-14 xxl:py-16">
                 <div className="flex flex-col gap-4">
                   <p className="text-[20px] leading-[140%] font-medium text-white xl:text-[22px] xxl:text-[26px]">
                     {perguntas[ativo].resposta}
@@ -153,7 +153,7 @@ export default function FAQ() {
                   {perguntas[ativo].link && (
                     <Link
                       href={perguntas[ativo].link.href}
-                      className="absolute right-8 bottom-8 inline-flex items-center gap-2 text-[14px] font-medium text-white opacity-90 hover:opacity-100 xl:text-[16px]"
+                      className="absolute right-8 bottom-8 inline-flex items-center gap-2 border-b border-transparent text-[14px] font-medium text-white opacity-90 transition-colors hover:border-white hover:opacity-100 xl:text-[16px]"
                     >
                       {perguntas[ativo].link.label}
                       <MoveRight className="h-4 w-4" />

--- a/src/components/layout/Home/Hero.tsx
+++ b/src/components/layout/Home/Hero.tsx
@@ -13,15 +13,15 @@ export default function Hero() {
   return (
     <section
       id="hero"
-      className="relative overflow-hidden rounded-2xl bg-linear-to-r from-[#e3f0ff] via-[#f8f5ff] to-[#ffeef5]"
+      className="relative flex h-[calc(100vh-100px)] items-center overflow-hidden rounded-2xl bg-linear-to-r from-[#e3f0ff] via-[#f8f5ff] to-[#ffeef5] lg:h-auto xxl:h-[calc(100vh-100px)]"
     >
       {/* Container em coluna única */}
-      <div className="mx-auto flex max-w-[1360px] flex-col items-center px-5 pt-32 md:px-7 md:pt-[88px] lg:px-10">
+      <div className="max-w-auto mx-auto flex flex-col items-center p-10 md:px-7 md:pt-[88px] lg:flex-row lg:gap-10 lg:py-20 xl:gap-20 xl:px-4 xxl:py-10">
         {/* TEXTO */}
         <div className="text-center">
           <Title />
 
-          <p className="mx-auto mt-6 max-w-[377px] text-[12px] leading-[140%] text-[#5C5C65] sm:text-[14px] md:text-[16px]">
+          <p className="mx-auto mt-8 max-w-[377px] text-[12px] leading-[140%] text-[#5C5C65] sm:text-[14px] md:text-[16px] xl:mt-14">
             Uma rede colaborativa para desenvolvimento de soluções digitais com
             aprendizado prático, mentoria e trabalho em equipe.
           </p>
@@ -48,16 +48,17 @@ export default function Hero() {
           <Image
             src="https://res.cloudinary.com/daxa1bpny/image/upload/v1764190245/ui_assets/heroBackground_tablet.svg"
             alt="Pessoas colaborando em um projeto"
-            width={848}
+            width={500}
             height={382}
             priority
+            className="lg:w-[400px] xl:w-[600px] xxl:w-[700px]"
           />
         </div>
 
         {/* INDICADOR DE SCROLL */}
-        <div className="absolute right-6 bottom-6 hidden items-center gap-2 text-[#5C5C65] md:right-6 md:bottom-6 md:flex lg:right-10 lg:bottom-10">
+        <div className="absolute bottom-5 flex gap-2 text-[#5C5C65] md:hidden lg:right-10 lg:bottom-10">
           <ArrowDown className="h-4 w-4 md:hidden" />
-          <Mouse className="lg:block" />
+          <Mouse className="hidden lg:block" />
           <p className="text-[10px] md:text-[11px] lg:text-[14px]">
             rolar para baixo
           </p>

--- a/src/components/layout/Home/Hero.tsx
+++ b/src/components/layout/Home/Hero.tsx
@@ -13,30 +13,30 @@ export default function Hero() {
   return (
     <section
       id="hero"
-      className="relative flex h-[calc(100vh-100px)] items-center overflow-hidden rounded-2xl bg-linear-to-r from-[#e3f0ff] via-[#f8f5ff] to-[#ffeef5] lg:h-auto xxl:h-[calc(100vh-100px)]"
+      className="relative flex h-[calc(100vh-100px)] items-center overflow-hidden rounded-2xl bg-linear-to-r from-[#e3f0ff] via-[#f8f5ff] to-[#ffeef5] lg:h-auto"
     >
       {/* Container em coluna única */}
-      <div className="max-w-auto mx-auto flex flex-col items-center p-10 md:px-7 md:pt-[88px] lg:flex-row lg:gap-10 lg:py-20 xl:gap-20 xl:px-4 xxl:py-10">
+      <div className="max-w-auto mx-auto flex flex-col items-center p-10 md:px-7 md:pb-0 lg:flex-row lg:items-end lg:gap-10 lg:pt-10 lg:pb-0 xl:gap-20 xl:px-4 xxl:lg:pt-20">
         {/* TEXTO */}
-        <div className="text-center">
+        <div className="pb-8 text-center lg:text-left">
           <Title />
 
-          <p className="mx-auto mt-8 max-w-[377px] text-[12px] leading-[140%] text-[#5C5C65] sm:text-[14px] md:text-[16px] xl:mt-14">
+          <p className="mx-auto mt-8 max-w-[377px] text-[12px] leading-[140%] text-[#5C5C65] sm:text-[14px] md:text-[16px] lg:mx-0 xl:mt-14 xxl:max-w-[600px] xxl:text-[25px]">
             Uma rede colaborativa para desenvolvimento de soluções digitais com
             aprendizado prático, mentoria e trabalho em equipe.
           </p>
 
           {/* CTA */}
-          <div className="mt-8 flex justify-center">
+          <div className="mt-8 flex justify-center lg:justify-normal">
             <Link href="/login">
-              <Button className="flex h-10 justify-between rounded-[84px] bg-[#35343C] p-[3px] pl-5 hover:bg-[#35343C]/90">
-                <span className="text-[14px] font-medium md:text-[16px]">
+              <Button className="flex h-10 justify-between rounded-[84px] bg-[#35343C] p-[3px] pl-5 hover:bg-[#35343C]/90 xxl:h-16 xxl:w-auto xxl:pr-2">
+                <span className="text-[14px] font-medium md:text-[16px] lg:pr-2 xxl:text-[20px]">
                   {status === 'unauthenticated'
                     ? 'Faça login'
                     : 'Acesse o Dashboard'}
                 </span>
-                <span className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-white">
-                  <ArrowUpRight className="h-5 w-5 text-[#35343C]" />
+                <span className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-white xxl:h-[50px] xxl:w-[50px]">
+                  <ArrowUpRight className="h-5 w-5 text-[#35343C] xxl:h-7! xxl:w-7!" />
                 </span>
               </Button>
             </Link>
@@ -51,7 +51,7 @@ export default function Hero() {
             width={500}
             height={382}
             priority
-            className="lg:w-[400px] xl:w-[600px] xxl:w-[700px]"
+            className="xl:w-[600px] xxl:w-[700px]"
           />
         </div>
 

--- a/src/components/layout/Home/Title.tsx
+++ b/src/components/layout/Home/Title.tsx
@@ -4,10 +4,10 @@ import Image from 'next/image';
 
 export default function Title() {
   return (
-    <h1 className="relative text-center text-[29px] leading-[140%] font-semibold sm:text-[35px] sm:leading-[120%] md:text-[45px] xl:text-[45px] xxl:text-[56px]">
+    <h1 className="relative text-center text-[29px] leading-[140%] font-semibold sm:text-[35px] sm:leading-[120%] md:text-[40px] lg:text-left xl:text-[45px] xxl:text-[70px]">
       {/* Linha 1 */}
       <span className="relative inline-block">
-        Conectando
+        Conectando <span className="hidden lg:inline-block">talentos</span>
         <Image
           src="/shineIcon.svg"
           alt=""
@@ -21,7 +21,8 @@ export default function Title() {
       <br />
 
       {/* Linha 2 */}
-      <span className="inline-block">talentos a projetos reais,</span>
+      <span className="inline-block lg:hidden">talentos a projetos reais,</span>
+      <span className="hidden lg:inline-block">a projetos reais,</span>
 
       <br />
 

--- a/src/components/layout/Home/Title.tsx
+++ b/src/components/layout/Home/Title.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 
 export default function Title() {
   return (
-    <h1 className="relative text-center text-[30px] leading-[120%] font-semibold sm:text-[38px] md:text-[48px] xl:text-[56px] xxl:text-[72px]">
+    <h1 className="relative text-center text-[29px] leading-[140%] font-semibold sm:text-[35px] sm:leading-[120%] md:text-[45px] xl:text-[45px] xxl:text-[56px]">
       {/* Linha 1 */}
       <span className="relative inline-block">
         Conectando


### PR DESCRIPTION
re #476

Fiz alterações da Issue

Na home agora a partir de LG, a imagem fica ao lado, no md fica cobre a tela toda.
<img width="3200" height="1084" alt="image" src="https://github.com/user-attachments/assets/4e5a238d-05a1-48f0-ba06-15c6a6982f5f" />

<img width="3200" height="1084" alt="image" src="https://github.com/user-attachments/assets/d0937ae8-4746-400e-b6db-423878760047" />

 dei mais espaço para o pagrafo no sobre nós
<img width="3200" height="1084" alt="image" src="https://github.com/user-attachments/assets/84e42101-5a96-4879-9645-f0dcfc6a83e1" />

agora no faq os perguntas acompanham o tamanho do card de resposta 
<img width="3200" height="1084" alt="image" src="https://github.com/user-attachments/assets/8d71036a-a4eb-445f-ac52-7fa80a95b5e5" />

