### PR TITLE
fix(hero.tsx): tira a imagem do breakpoint md na seção hero

### DIFF
--- a/src/components/layout/Home/Footer.tsx
+++ b/src/components/layout/Home/Footer.tsx
@@ -12,7 +12,7 @@ export default function Footer() {
               src="/logo-trycatch-colmeia.png"
               alt="TryCatch"
               fill
-              className="object-contain"
+              className="w-auto! object-contain"
             />
           </div>
 

--- a/src/components/layout/Home/Hero.tsx
+++ b/src/components/layout/Home/Hero.tsx
@@ -13,10 +13,10 @@ export default function Hero() {
   return (
     <section
       id="hero"
-      className="relative flex h-[calc(100vh-100px)] items-center overflow-hidden rounded-2xl bg-linear-to-r from-[#e3f0ff] via-[#f8f5ff] to-[#ffeef5] lg:h-auto"
+      className="relative flex h-[calc(100vh-100px)] items-center overflow-hidden rounded-2xl bg-linear-to-r from-[#e3f0ff] via-[#f8f5ff] to-[#ffeef5] md:h-auto"
     >
       {/* Container em coluna única */}
-      <div className="max-w-auto mx-auto flex flex-col items-center p-10 md:px-7 md:pb-0 lg:flex-row lg:items-end lg:gap-10 lg:pt-10 lg:pb-0 xl:gap-20 xl:px-4 xxl:lg:pt-20">
+      <div className="max-w-auto mx-auto flex flex-col items-center p-10 md:my-4 md:px-7 lg:flex-row lg:items-end lg:gap-10 lg:pt-10 lg:pb-0 xl:gap-20 xl:px-4 xxl:lg:pt-20">
         {/* TEXTO */}
         <div className="pb-8 text-center lg:text-left">
           <Title />
@@ -43,8 +43,8 @@ export default function Hero() {
           </div>
         </div>
 
-        {/* IMAGEM — SOMENTE TABLET+ */}
-        <div className="mt-12 hidden md:block">
+        {/* IMAGEM — SOMENTE lg+ */}
+        <div className="mt-12 hidden lg:block">
           <Image
             src="https://res.cloudinary.com/daxa1bpny/image/upload/v1764190245/ui_assets/heroBackground_tablet.svg"
             alt="Pessoas colaborando em um projeto"

--- a/src/components/layout/Home/Title.tsx
+++ b/src/components/layout/Home/Title.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 
 export default function Title() {
   return (
-    <h1 className="relative text-center text-[29px] leading-[140%] font-semibold sm:text-[35px] sm:leading-[120%] md:text-[40px] lg:text-left xl:text-[45px] xxl:text-[70px]">
+    <h1 className="relative text-center text-[29px] leading-[140%] font-semibold sm:text-[35px] sm:leading-[120%] md:mt-10 md:text-[40px] lg:text-left xl:text-[45px] xxl:text-[70px]">
       {/* Linha 1 */}
       <span className="relative inline-block">
         Conectando <span className="hidden lg:inline-block">talentos</span>


### PR DESCRIPTION
fix #483

### Imagem não aparece mais no breakpoint md, que engloba as larguras entre 780 até 1139px , isso corrige o problema relatado na Issue #483 
<img width="812" height="590" alt="image" src="https://github.com/user-attachments/assets/31dbf452-187b-4b69-aa93-31aba072c1b1" />
