### PR TITLE
Feature/portfolio visibility control

### DIFF
--- a/docs/03 - tecnico/modelagem/modelagem-dados.md
+++ b/docs/03 - tecnico/modelagem/modelagem-dados.md
@@ -5,12 +5,25 @@ Camada: 3 --- Técnico
 
 ## 1. Entidades Principais
 
--   User
--   Project
--   Feedback
--   Invite
--   Stack
--   Skill
+### User
+
+Campos relevantes adicionados para controle de identidade pública e visibilidade:
+
+- userName: identificador público único (@unique)
+- showEmail: controla exibição do email
+- showGithub: controla exibição do GitHub
+- showLinkedin: controla exibição do LinkedIn
+- showCertificates: controla exibição de certificados
+- showProjects: controla exibição de projetos
+- showFeedback: controla exibição de feedbacks
+- portfolioPublic: define se o portfólio é público ou privado
+
+O campo emailVisible foi removido para padronização.
+### Project
+### Feedback
+### Invite
+### Stack
+### Skill
 
 ## 2. Relações
 

--- a/prisma/migrations/20260214203536_show_user_data/migration.sql
+++ b/prisma/migrations/20260214203536_show_user_data/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `emailVisible` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "emailVisible",
+ADD COLUMN     "portfolioPublic" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "showCertificates" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "showEmail" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "showFeedback" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "showGithub" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "showLinkedin" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "showProjects" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260215142740_add_username_uer/migration.sql
+++ b/prisma/migrations/20260215142740_add_username_uer/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userName]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "userName" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_userName_key" ON "User"("userName");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ enum RequestStatus {
 model User {
   id                String             @id @default(cuid())
   name              String
+  userName          String?            @unique
   email             String             @unique
   createdAt         DateTime           @default(now())
   avatar            String?
@@ -43,8 +44,7 @@ model User {
   updatedAt         DateTime           @updatedAt
   bio               String?
   isActive          Boolean            @default(true)
-  role              UserRole           @default(USER)
-  emailVisible      Boolean            @default(false)
+  role              UserRole           @default(USER)  
   feedbacksGiven    Feedback[]         @relation("FeedbackGiver")
   feedbacksReceived Feedback[]         @relation("FeedbackReceiver")
   projects          Project[]          @relation("ProjectOwner")
@@ -52,6 +52,14 @@ model User {
   availability      UserAvailability[]
   certificates      UserCertificate[]
   skills            UserSkill[]
+
+  showEmail         Boolean             @default(false)
+  showGithub        Boolean             @default(true)
+  showLinkedin      Boolean             @default(true)
+  showCertificates  Boolean             @default(true)
+  showProjects      Boolean             @default(true)
+  showFeedback      Boolean             @default(false)
+  portfolioPublic   Boolean             @default(true)
 }
 
 model Skill {

--- a/src/app/api/portfolio/[id]/route.ts
+++ b/src/app/api/portfolio/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { NextRequest, NextResponse } from 'next/server';
 import { MESSAGES, buildResponse } from '@/constants/messages';
+import { buildPublicPortfolio } from '@/lib/user/portfolio-visibility';
 
 interface Params {
   params: {
@@ -12,10 +13,9 @@ export async function GET(_request: NextRequest, { params }: Params) {
   const { id } = params;
 
   try {
-    const portfolio = await prisma.user.findFirst({
+    const portfolio = await prisma.user.findUnique({
       where: {
         id,
-        isActive: true,
       },
       select: {
         id: true,
@@ -26,7 +26,14 @@ export async function GET(_request: NextRequest, { params }: Params) {
         github: true,
         linkedin: true,
         email: true,
-        emailVisible: true,
+        isActive: true,
+        showEmail: true,
+        showGithub: true,
+        showLinkedin: true,
+        showCertificates: true,
+        showProjects: true,
+        showFeedback: true,
+        portfolioPublic: true,
 
         skills: {
           include: {
@@ -70,10 +77,23 @@ export async function GET(_request: NextRequest, { params }: Params) {
       });
     }
 
-    const publicPortfolio = {
-      ...portfolio,
-      email: portfolio.emailVisible ? portfolio.email : null,
-    };
+    if (!portfolio.isActive) {
+      return buildResponse({
+        success: false,
+        message: MESSAGES.USER.NOT_FOUND,
+        status: 404,
+      });
+    }
+
+    if (!portfolio.portfolioPublic) {
+      return buildResponse({
+        success: false,
+        message: MESSAGES.PORTFOLIO.PORTFOLIO_PRIVATE,
+        status: 403,
+      });
+    }
+
+    const publicPortfolio = buildPublicPortfolio(portfolio);
 
     return NextResponse.json(publicPortfolio, { status: 200 });
   } catch (error) {

--- a/src/app/api/portfolio/me/route.ts
+++ b/src/app/api/portfolio/me/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
 import { checkAuth } from '@/lib/check-auth';
 import { z } from 'zod';
@@ -8,12 +9,10 @@ import { ROLE_GROUPS } from '@/lib/roles';
 const updatePortfolioSchema = z.object({
   bio: z.string().optional(),
   avatar: z.string().url().optional(),
-  emailVisible: z.boolean().optional(),
   skills: z
     .array(
       z.object({
         skillId: z.string().min(1, 'ID inválido.'),
-        level: z.string().optional(),
       })
     )
     .optional(),
@@ -29,6 +28,13 @@ const updatePortfolioSchema = z.object({
       })
     )
     .optional(),
+  showEmail: z.boolean().optional(),
+  showGithub: z.boolean().optional(),
+  showLinkedin: z.boolean().optional(),
+  showCertificates: z.boolean().optional(),
+  showProjects: z.boolean().optional(),
+  showFeedback: z.boolean().optional(),
+  portfolioPublic: z.boolean().optional(),
 });
 
 export async function GET() {
@@ -46,11 +52,17 @@ export async function GET() {
       id: true,
       name: true,
       email: true,
-      emailVisible: true,
       github: true,
       linkedin: true,
       bio: true,
       avatar: true,
+      showEmail: true,
+      showGithub: true,
+      showLinkedin: true,
+      showCertificates: true,
+      showProjects: true,
+      showFeedback: true,
+      portfolioPublic: true,
 
       // Skills vinculadas ao usuário
       skills: {
@@ -115,14 +127,92 @@ export async function PATCH(request: NextRequest) {
     });
   }
 
-  const { bio, avatar, emailVisible, skills, certificates } = parsed.data;
+  const {
+    bio,
+    avatar,
+    skills,
+    certificates,
+    showEmail,
+    showGithub,
+    showLinkedin,
+    showCertificates,
+    showProjects,
+    showFeedback,
+    portfolioPublic,
+  } = parsed.data;
+
+  // `Prisma.UserUpdateInput` é o tipo que o Prisma aceita no campo `data` do update.
+  // Usamos `Partial<>` porque no PATCH os campos são opcionais.
+  // Isso permite montar dinamicamente um objeto apenas com os campos enviados,
+  // mantendo segurança de tipos (evita usar `any`) e impedindo atualizar campos inválidos.
+
+  const updateData: Partial<Prisma.UserUpdateInput> = {};
+
+  if (bio !== undefined) updateData.bio = bio;
+  if (avatar !== undefined) updateData.avatar = avatar;
+  if (showEmail !== undefined) updateData.showEmail = showEmail;
+  if (showGithub !== undefined) updateData.showGithub = showGithub;
+  if (showLinkedin !== undefined) updateData.showLinkedin = showLinkedin;
+  if (showCertificates !== undefined)
+    updateData.showCertificates = showCertificates;
+  if (showProjects !== undefined) updateData.showProjects = showProjects;
+  if (showFeedback !== undefined) updateData.showFeedback = showFeedback;
+  if (portfolioPublic !== undefined)
+    updateData.portfolioPublic = portfolioPublic;
 
   const updatedUser = await prisma.user.update({
     where: { id: userId },
-    data: {
-      bio,
-      avatar,
-      emailVisible,
+    data: updateData,
+  });
+
+  const refreshedPortfolio = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      github: true,
+      linkedin: true,
+      bio: true,
+      avatar: true,
+      showEmail: true,
+      showGithub: true,
+      showLinkedin: true,
+      showCertificates: true,
+      showProjects: true,
+      showFeedback: true,
+      portfolioPublic: true,
+
+      // Skills vinculadas ao usuário
+      skills: {
+        include: { skill: true },
+      },
+
+      // Certificados
+      certificates: true,
+
+      // Feedbacks recebidos
+      feedbacksReceived: {
+        include: {
+          fromUser: {
+            select: { name: true, avatar: true },
+          },
+        },
+      },
+
+      // Projetos (via stacksTaken)
+      stacksTaken: {
+        include: {
+          stack: true,
+          project: {
+            select: {
+              id: true,
+              name: true,
+              status: true,
+            },
+          },
+        },
+      },
     },
   });
 
@@ -133,7 +223,6 @@ export async function PATCH(request: NextRequest) {
       data: skills.map((s) => ({
         userId,
         skillId: s.skillId,
-        level: s.level ?? 'BEGINNER',
       })),
     });
   }
@@ -156,7 +245,7 @@ export async function PATCH(request: NextRequest) {
   return buildResponse({
     success: true,
     message: MESSAGES.USER.UPDATED,
-    data: updatedUser,
+    data: refreshedPortfolio,
     status: 200,
   });
 }

--- a/src/app/api/portfolio/summary/route.ts
+++ b/src/app/api/portfolio/summary/route.ts
@@ -5,16 +5,18 @@ import { MESSAGES, buildResponse } from '@/constants/messages';
 export async function GET() {
   try {
     const users = await prisma.user.findMany({
-      where: { isActive: true },
+      where: { isActive: true, portfolioPublic: true },
       select: {
         id: true,
         name: true,
-        email: true,
         avatar: true,
         role: true,
         github: true,
         linkedin: true,
         bio: true,
+        showGithub: true,
+        showLinkedin: true,
+        showFeedback: true,
         skills: {
           select: {
             skill: {
@@ -51,9 +53,9 @@ export async function GET() {
         name: user.name,
         role: user.role,
         bio: user.bio,
-        github: user.github,
-        linkedin: user.linkedin,
-        feedback: averageFeedback,
+        github: user.showGithub ? user.github : null,
+        linkedin: user.showLinkedin ? user.linkedin : null,
+        feedback: user.showFeedback ? averageFeedback : null,
         skills: user.skills.map((us) => ({
           id: us.skill.id,
           name: us.skill.name,

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -68,6 +68,11 @@ export const MESSAGES = {
   LOGIN: {
     SUCCESS: 'Login realizado com sucesso.',
   },
+  PORTFOLIO: {
+    NOT_FOUND: 'Portfólio não encontrado.',
+    PORTFOLIO_PRIVATE: 'Este portfólio é privado.',
+    INTERNAL_ERROR: 'Erro interno ao processar portfólio.',
+  },
   PROJECT: {
     NOT_FOUND: 'Projeto não encontrado.',
     CREATED: 'Projeto criado com sucesso.',

--- a/src/lib/user/portfolio-visibility.ts
+++ b/src/lib/user/portfolio-visibility.ts
@@ -1,0 +1,41 @@
+type PublicPortfolioInput = {
+  id: string;
+  name: string;
+  role: string;
+  avatar: string | null;
+  bio: string | null;
+  email: string;
+  github: string | null;
+  linkedin: string | null;
+
+  showEmail: boolean;
+  showGithub: boolean;
+  showLinkedin: boolean;
+  showCertificates: boolean;
+  showProjects: boolean;
+  showFeedback: boolean;
+
+  certificates: unknown[];
+  feedbacksReceived: unknown[];
+  stacksTaken: unknown[];
+  skills: unknown[];
+};
+
+export function buildPublicPortfolio(user: PublicPortfolioInput) {
+  return {
+    id: user.id,
+    name: user.name,
+    role: user.role,
+    avatar: user.avatar,
+    bio: user.bio,
+
+    email: user.showEmail ? user.email : null,
+    github: user.showGithub ? user.github : null,
+    linkedin: user.showLinkedin ? user.linkedin : null,
+
+    certificates: user.showCertificates ? user.certificates : [],
+    feedbacks: user.showFeedback ? user.feedbacksReceived : [],
+    projects: user.showProjects ? user.stacksTaken : [],
+    skills: user.skills,
+  };
+}

--- a/src/tests/api/portfolio/portfolio-id.test.ts
+++ b/src/tests/api/portfolio/portfolio-id.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/portfolio/[id]/route';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+describe('GET /api/portfolio/[id]', () => {
+  it('should return 404 when user does not exist', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const request = {} as NextRequest;
+
+    const response = await GET(request, {
+      params: { id: 'non-existent-id' },
+    });
+
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+
+  it('should return 403 when portfolio is private', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      name: 'Test User',
+      role: 'USER',
+      avatar: null,
+      bio: null,
+      github: null,
+      linkedin: null,
+      email: 'test@test.com',
+      isActive: true,
+      showEmail: true,
+      showGithub: true,
+      showLinkedin: true,
+      showCertificates: true,
+      showProjects: true,
+      showFeedback: true,
+      portfolioPublic: false,
+      skills: [],
+      certificates: [],
+      feedbacksReceived: [],
+      stacksTaken: [],
+    });
+
+    const request = {} as NextRequest;
+
+    const response = await GET(request, {
+      params: { id: 'user-1' },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('should hide email when showEmail is false', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      name: 'Test User',
+      role: 'USER',
+      avatar: null,
+      bio: null,
+      github: null,
+      linkedin: null,
+      email: 'test@test.com',
+      isActive: true,
+      showEmail: false,
+      showGithub: true,
+      showLinkedin: true,
+      showCertificates: true,
+      showProjects: true,
+      showFeedback: true,
+      portfolioPublic: true,
+      skills: [],
+      certificates: [],
+      feedbacksReceived: [],
+      stacksTaken: [],
+    });
+
+    const request = {} as NextRequest;
+
+    const response = await GET(request, {
+      params: { id: 'user-1' },
+    });
+
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.email).toBeNull();
+  });
+
+  it('should hide feedbacks when showFeedback is false', async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      name: 'Test User',
+      role: 'USER',
+      avatar: null,
+      bio: null,
+      github: null,
+      linkedin: null,
+      email: 'test@test.com',
+      isActive: true,
+      showEmail: true,
+      showGithub: true,
+      showLinkedin: true,
+      showCertificates: true,
+      showProjects: true,
+      showFeedback: false,
+      portfolioPublic: true,
+      skills: [],
+      certificates: [],
+      feedbacksReceived: [
+        {
+          rating: 5,
+          fromUser: {
+            name: 'Another User',
+            avatar: null,
+          },
+        },
+      ],
+      stacksTaken: [],
+    });
+
+    const request = {} as NextRequest;
+
+    const response = await GET(request, {
+      params: { id: 'user-1' },
+    });
+
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.feedbacks).toEqual([]);
+  });
+});

--- a/src/tests/api/portfolio/portfolio-me.test.ts
+++ b/src/tests/api/portfolio/portfolio-me.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment node
+ */
+
+import { PATCH } from '@/app/api/portfolio/me/route';
+import { prisma } from '@/lib/prisma';
+import { checkAuth } from '@/lib/check-auth';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      update: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    userSkill: {
+      deleteMany: jest.fn(),
+      createMany: jest.fn(),
+    },
+    userCertificate: {
+      deleteMany: jest.fn(),
+      createMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+(prisma.user.findUnique as jest.Mock).mockResolvedValue({
+  id: 'user-1',
+  showEmail: false,
+  skills: [],
+  certificates: [],
+  feedbacksReceived: [],
+  stacksTaken: [],
+});
+
+describe('PATCH /api/portfolio/me', () => {
+  it('should update only provided fields', async () => {
+    (checkAuth as jest.Mock).mockResolvedValue({
+      authorized: true,
+      session: {
+        user: { id: 'user-1' },
+      },
+    });
+
+    (prisma.user.update as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      showEmail: false,
+    });
+
+    const request = {
+      json: async () => ({
+        showEmail: false,
+      }),
+    } as unknown as NextRequest;
+
+    // Usamos "!" (non-null assertion) porque neste teste garantimos
+    // que checkAuth retorna authorized = true, então PATCH nunca retorna undefined.
+    const response = (await PATCH(request))!;
+    const body = await response.json();
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { showEmail: false },
+    });
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('should replace skills when skills are provided', async () => {
+    (checkAuth as jest.Mock).mockResolvedValue({
+      authorized: true,
+      session: {
+        user: { id: 'user-1' },
+      },
+    });
+
+    const request = {
+      json: async () => ({
+        skills: [{ skillId: 'skill-1' }, { skillId: 'skill-2' }],
+      }),
+    } as unknown as NextRequest;
+
+    (prisma.user.update as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+    });
+
+    const response = (await PATCH(request))!;
+
+    expect(prisma.userSkill.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+    });
+
+    expect(prisma.userSkill.createMany).toHaveBeenCalledWith({
+      data: [
+        { userId: 'user-1', skillId: 'skill-1' },
+        { userId: 'user-1', skillId: 'skill-2' },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/tests/api/portfolio/portfolio-summary.test.ts
+++ b/src/tests/api/portfolio/portfolio-summary.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/portfolio/summary/route';
+import { prisma } from '@/lib/prisma';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+describe('GET /api/portfolio/summary', () => {
+  it('should return only public active users', async () => {
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'user-1',
+        name: 'Public User',
+        avatar: null,
+        role: 'USER',
+        github: 'https://github.com/test',
+        linkedin: null,
+        bio: null,
+        showGithub: true,
+        showLinkedin: true,
+        showFeedback: true,
+        skills: [],
+        feedbacksReceived: [],
+      },
+    ]);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.length).toBe(1);
+    expect(body[0].id).toBe('user-1');
+  });
+
+  it('should hide github when showGithub is false', async () => {
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'user-1',
+        name: 'User Test',
+        avatar: null,
+        role: 'USER',
+        github: 'https://github.com/test',
+        linkedin: null,
+        bio: null,
+        showGithub: false,
+        showLinkedin: true,
+        showFeedback: true,
+        skills: [],
+        feedbacksReceived: [],
+      },
+    ]);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body[0].github).toBeNull();
+  });
+});


### PR DESCRIPTION


BREAKING CHANGE:
- Removed `emailVisible` field from User model.
- Added `username` as a unique field.
- Added portfolio visibility flags (showEmail, showGithub, showLinkedin, showCertificates, showProjects, showFeedback, portfolioPublic).

This requires running database migrations and updating related API routes.

- Applied portfolio visibility rules in public and summary routes
- Extracted buildPublicPortfolio to lib for reuse and separation of concerns
- Updated /portfolio/me PATCH to use partial update with Prisma types
- Ensured consistency between public, summary and private portfolio routes
- Updated technical documentation

- Added tests for GET /portfolio/[id] (existence, visibility, flags)
- Added tests for GET /portfolio/summary (public users and visibility flags)
- Added tests for PATCH /portfolio/me (partial updates and skill replacement)
- Mocked Prisma and authentication for route isolation
<img width="586" height="315" alt="Image" src="https://github.com/user-attachments/assets/08e3da75-f07b-4d09-9b48-071ccb3f71a3" />