### PR TITLE
Feat/mails

### DIFF
--- a/docs/01 - estrategia/comunicacao/texto-transacional-emails.md
+++ b/docs/01 - estrategia/comunicacao/texto-transacional-emails.md
@@ -1,0 +1,162 @@
+# Documento Estratégico --- Comunicação Transacional (TryCatch)
+
+#### Classificação: Documento Estratégico
+
+#### Camada: 1 --- Documentos Estratégicos
+
+#### Status: Versão inicial consolidada
+
+------------------------------------------------------------------------
+
+### 1. Objetivo do Documento
+
+Este documento define as diretrizes estratégicas para a comunicação
+transacional do TryCatch.
+
+Ele orienta o domínio de **comunicação institucional automatizada**,
+estabelecendo critérios que devem embasar:
+
+-   Criação de templates de email;
+-   Definição de tom institucional em fluxos automáticos;
+-   Decisões relacionadas à clareza, segurança e acessibilidade textual.
+
+Este documento não descreve implementações técnicas, mas orienta
+documentos de produto e decisões de layout e conteúdo.
+
+------------------------------------------------------------------------
+
+### 2. Escopo Estratégico
+
+Este documento cobre:
+
+-   Diretrizes para textos de e-mails automáticos;
+-   Princípios de clareza e objetividade;
+-   Critérios de segurança comunicacional;
+-   Padrões mínimos de acessibilidade textual.
+
+Fora de escopo:
+
+-   Implementação técnica de envio de emails;
+-   Escolha de provedores (ex.: Resend);
+-   Estrutura de código;
+-   Detalhamento visual de layout (tratado em documento técnico ou de
+    identidade visual).
+
+------------------------------------------------------------------------
+
+### 3. Princípios Norteadores
+
+#### 3.1 Clareza
+
+A mensagem deve ser compreensível na primeira leitura.\
+Evitar termos ambíguos ou técnicos desnecessários.
+
+#### 3.2 Objetividade
+
+E-mails transacionais devem ser diretos.\
+Devem comunicar ação, contexto e consequência sem excesso de narrativa.
+
+#### 3.3 Segurança
+
+Nunca expor informações sensíveis.\
+Evitar confirmação explícita de existência de conta quando não
+necessário.
+
+#### 3.4 Neutralidade e Profissionalismo
+
+Linguagem neutra, inclusiva e respeitosa.\
+Evitar tom promocional em comunicações operacionais.
+
+#### 3.5 Acessibilidade Textual
+
+O conteúdo não deve depender exclusivamente de elementos visuais para
+compreensão.\
+Evitar instruções como "clique no botão verde" sem contexto textual
+equivalente.
+
+------------------------------------------------------------------------
+
+### 4. Diretrizes Estratégicas
+
+-   Todo email deve conter contexto claro do motivo do envio;
+-   Deve conter identificação institucional (TryCatch);
+-   Deve indicar ação esperada quando aplicável;
+-   Deve evitar excesso de informações secundárias;
+-   Deve manter consistência de tom entre diferentes fluxos;
+-   Deve ser compreensível mesmo sem carregamento de imagens.
+
+------------------------------------------------------------------------
+
+### 5. Relação com Outros Documentos
+
+Impacta diretamente:
+
+-   Documento de Produto --- Convites;
+-   Documento de Produto --- Sistema de Feedback;
+-   Documento de Produto --- Gestão de Projetos;
+-   Documento Técnico --- Templates de Email;
+-   Documento Técnico --- Arquitetura Geral.
+
+Deve estar alinhado com:
+
+-   Documento 0 --- Visão Geral e Governança;
+-   Documento Estratégico de Marca e Identidade (quando aplicável).
+
+------------------------------------------------------------------------
+
+### 6. Antipadrões Estratégicos
+
+-   Uso de linguagem promocional em e-mails operacionais;
+-   Excesso de texto irrelevante;
+-   Dependência exclusiva de elementos visuais;
+-   Exposição desnecessária de dados sensíveis;
+-   Comunicação ambígua sobre segurança de conta.
+
+------------------------------------------------------------------------
+
+### 7. Critérios de Avaliação e Conformidade
+
+Antes da aprovação de qualquer template, verificar:
+
+-   O objetivo do email está claro?
+-   Existe ação explícita quando necessário?
+-   A linguagem é neutra e profissional?
+-   O conteúdo é compreensível sem elementos visuais?
+-   Informações sensíveis estão protegidas?
+
+Se alguma resposta for negativa, o template deve ser revisado.
+
+------------------------------------------------------------------------
+
+### 8. Evolução do Documento
+
+Este documento pode evoluir conforme:
+
+-   Crescimento da base de usuários;
+-   Necessidade de formalização adicional de comunicação;
+-   Revisões estratégicas de marca;
+-   Ampliação de canais de comunicação (ex.: notificações internas).
+
+Revisões devem envolver Produto e Marketing.
+
+------------------------------------------------------------------------
+
+### 9. Histórico de Decisões Estratégicas
+
+-   Formalização da comunicação transacional como domínio estratégico;
+-   Definição de clareza, segurança e acessibilidade como princípios
+    centrais;
+-   Separação entre comunicação operacional e comunicação promocional.
+
+------------------------------------------------------------------------
+
+### 10. Status do Documento
+
+Status atual: Consolidado inicial.\
+Grau de estabilidade: Médio.\
+Pode evoluir conforme amadurecimento da comunicação institucional.
+
+------------------------------------------------------------------------
+
+Observação: Este documento está alinhado ao Documento 0 --- Visão Geral,
+Governança e Arquitetura da Documentação.

--- a/docs/03 - tecnico/adrs/adr-email-templates.md
+++ b/docs/03 - tecnico/adrs/adr-email-templates.md
@@ -1,0 +1,89 @@
+# ADR-XXX — Padronização de Templates de Email com React Email
+
+## Status
+Aprovado
+
+## Contexto
+
+O sistema TryCatch possui múltiplos emails transacionais:
+
+- Solicitação de convite (admin)
+- Confirmação de solicitação (usuário)
+- Reset de senha
+- Contato
+
+Inicialmente alguns emails utilizavam HTML inline diretamente no service,
+o que gerava:
+
+- Duplicação de estrutura
+- Dificuldade de manutenção
+- Inconsistência visual
+- Acoplamento entre layout e lógica
+
+## Decisão
+
+Adotar **React Email** como padrão oficial para criação de templates.
+
+Definições adotadas:
+
+- Todos os templates devem usar `EmailLayout`
+- Nenhum HTML inline será utilizado em services
+- Envio centralizado via `lib/mail`
+- Utilização do SDK Resend
+- Instância única de `resend`
+
+Estrutura definida:
+
+```
+lib/
+  mail/
+    templates/
+      layout/
+         layout.tsx
+         emails-styles.ts
+      contact-sender.tsx      
+      invite-request-confirmation.tsx
+      invite-request-receiver.tsx
+      invite-request-sender.tsx      
+      reset-password.tsx
+    resend.ts
+    send-invite-request-confirmation-email.ts
+    send-invite-request-email.ts
+    send-reset-password-email.ts
+```
+
+## Consequências
+
+### Positivas
+
+- Padronização visual
+- Reutilização de layout
+- Melhor testabilidade
+- Melhor separação de responsabilidades
+- Facilidade de manutenção futura
+
+### Negativas
+
+- Pequeno aumento de complexidade inicial
+- Dependência adicional (React Email)
+
+## Alternativas consideradas
+
+- Manter HTML inline
+- Utilizar templates do próprio Resend
+- Utilizar apenas string HTML simples
+
+Todas descartadas por menor escalabilidade e padronização.
+
+## Impacto arquitetural
+
+Camada afetada:
+Infraestrutura / Comunicação
+
+Não impacta:
+- Banco de dados
+- Domínio
+- Regras de negócio
+
+## Data
+2026-02-25

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
+        "@react-email/components": "^1.0.8",
         "@tailwindcss/postcss": "^4.1.11",
         "axios": "^1.11.0",
         "bcryptjs": "^3.0.3",
@@ -5791,6 +5792,355 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-email/body": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.1.tgz",
+      "integrity": "sha512-ljDiQiJDu/Fq//vSIIP0z5Nuvt4+DX1RqGasstChDGJB/14ogd4VdNS9aacoede/ZjGy3o3Qb+cxyS+XgM6SwQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/button": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.1.tgz",
+      "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-block": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.1.tgz",
+      "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-inline": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.6.tgz",
+      "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/column": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/column/-/column-0.0.14.tgz",
+      "integrity": "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/components": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@react-email/components/-/components-1.0.8.tgz",
+      "integrity": "sha512-zY81ED6o5MWMzBkr9uZFuT24lWarT+xIbOZxI6C9dsFmCWBczM8IE1BgOI8rhpUK4JcYVDy1uKxYAFqsx2Bc4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/body": "0.2.1",
+        "@react-email/button": "0.2.1",
+        "@react-email/code-block": "0.2.1",
+        "@react-email/code-inline": "0.0.6",
+        "@react-email/column": "0.0.14",
+        "@react-email/container": "0.0.16",
+        "@react-email/font": "0.0.10",
+        "@react-email/head": "0.0.13",
+        "@react-email/heading": "0.0.16",
+        "@react-email/hr": "0.0.12",
+        "@react-email/html": "0.0.12",
+        "@react-email/img": "0.0.12",
+        "@react-email/link": "0.0.13",
+        "@react-email/markdown": "0.0.18",
+        "@react-email/preview": "0.0.14",
+        "@react-email/render": "2.0.4",
+        "@react-email/row": "0.0.13",
+        "@react-email/section": "0.0.17",
+        "@react-email/tailwind": "2.0.5",
+        "@react-email/text": "0.1.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/container": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.16.tgz",
+      "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/font": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@react-email/font/-/font-0.0.10.tgz",
+      "integrity": "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/head": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/head/-/head-0.0.13.tgz",
+      "integrity": "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/heading": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.16.tgz",
+      "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/hr": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.12.tgz",
+      "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/html": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/html/-/html-0.0.12.tgz",
+      "integrity": "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/img": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.12.tgz",
+      "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/link": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.13.tgz",
+      "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/markdown": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@react-email/markdown/-/markdown-0.0.18.tgz",
+      "integrity": "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^15.0.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/preview": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.14.tgz",
+      "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/render": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.4.tgz",
+      "integrity": "sha512-kht2oTFQ1SwrLpd882ahTvUtNa9s53CERHstiTbzhm6aR2Hbykp/mQ4tpPvsBGkKAEvKRlDEoooh60Uk6nHK1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/row": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/row/-/row-0.0.13.tgz",
+      "integrity": "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/section": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@react-email/section/-/section-0.0.17.tgz",
+      "integrity": "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/tailwind": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@react-email/tailwind/-/tailwind-2.0.5.tgz",
+      "integrity": "sha512-7Ey+kiWliJdxPMCLYsdDts8ffp4idlP//w4Ui3q/A5kokVaLSNKG8DOg/8qAuzWmRiGwNQVOKBk7PXNlK5W+sg==",
+      "license": "MIT",
+      "dependencies": {
+        "tailwindcss": "^4.1.18"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@react-email/body": "0.2.1",
+        "@react-email/button": "0.2.1",
+        "@react-email/code-block": "0.2.1",
+        "@react-email/code-inline": "0.0.6",
+        "@react-email/container": "0.0.16",
+        "@react-email/heading": "0.0.16",
+        "@react-email/hr": "0.0.12",
+        "@react-email/img": "0.0.12",
+        "@react-email/link": "0.0.13",
+        "@react-email/preview": "0.0.14",
+        "@react-email/text": "0.1.6",
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/body": {
+          "optional": true
+        },
+        "@react-email/button": {
+          "optional": true
+        },
+        "@react-email/code-block": {
+          "optional": true
+        },
+        "@react-email/code-inline": {
+          "optional": true
+        },
+        "@react-email/container": {
+          "optional": true
+        },
+        "@react-email/heading": {
+          "optional": true
+        },
+        "@react-email/hr": {
+          "optional": true
+        },
+        "@react-email/img": {
+          "optional": true
+        },
+        "@react-email/link": {
+          "optional": true
+        },
+        "@react-email/preview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-email/tailwind/node_modules/tailwindcss": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-email/text": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.6.tgz",
+      "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.10.1.tgz",
@@ -5830,6 +6180,34 @@
       "integrity": "sha512-jGTk8UD/RdjsNZW8qq10r0RBvxL8OWtoT+kImlzPDFilmozzM+9QmIJsmze9UiSBrFU45ZxhTYBypn9q9z/VfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -11010,7 +11388,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11282,7 +11659,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13889,6 +14265,96 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/html-to-text/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -16736,6 +17202,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -17523,6 +17998,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -18707,6 +19194,19 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -18829,6 +19329,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/pegjs": {
@@ -19195,7 +19704,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -19359,6 +19867,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process": {
@@ -20539,6 +21056,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
+    "@react-email/components": "^1.0.8",
     "@tailwindcss/postcss": "^4.1.11",
     "axios": "^1.11.0",
     "bcryptjs": "^3.0.3",

--- a/src/app/api/invite-request/route.ts
+++ b/src/app/api/invite-request/route.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 import { MESSAGES, buildResponse } from '@/constants/messages';
 import { z } from 'zod';
 import { sendInviteRequestEmail } from '@/lib/mail/send-invite-request-email';
+import { sendInviteRequestConfirmationEmail } from '@/lib/mail/send-invite-request-confirmation-email';
 
 const inviteRequestSchema = z.object({
   name: z.string().min(3, 'Nome inválido'),
@@ -56,11 +57,23 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    // formatação simples (ideal: usar util de data)
+    const requestDate = new Date().toLocaleString('pt-BR');
+
+    // Email para administrador
     await sendInviteRequestEmail({
       name,
       email,
       linkedin,
       role,
+    });
+
+    // Email de confirmação para o solicitante
+    await sendInviteRequestConfirmationEmail({
+      name,
+      email,
+      requestDate,
+      requestId: inviteRequest.id,
     });
 
     return buildResponse({

--- a/src/lib/mail/resend.ts
+++ b/src/lib/mail/resend.ts
@@ -1,10 +1,9 @@
 import { Resend } from 'resend';
 
-export const resend = () => {
-  if (!process.env.RESEND_API_KEY) {
-    console.warn('RESEND_API_KEY is not defined');
-    return;
-  }
+const apiKey = process.env.RESEND_API_KEY;
 
-  return new Resend(process.env.RESEND_API_KEY);
-};
+if (!apiKey) {
+  throw new Error('RESEND_API_KEY is not defined');
+}
+
+export const resend = new Resend(apiKey);

--- a/src/lib/mail/send-invite-request-confirmation-email.ts
+++ b/src/lib/mail/send-invite-request-confirmation-email.ts
@@ -1,0 +1,28 @@
+import { resend } from '@/lib/mail/resend';
+import { InviteRequestConfirmationEmail } from '@/lib/mail/templates/invite-request-confirmation';
+
+type SendInviteRequestConfirmationEmailProps = {
+  name: string;
+  email: string;
+  requestDate: string;
+  requestId: string;
+};
+
+export async function sendInviteRequestConfirmationEmail({
+  name,
+  email,
+  requestDate,
+  requestId,
+}: SendInviteRequestConfirmationEmailProps) {
+  await resend.emails.send({
+    from: 'TryCatch <no-reply@trycatch.app.br>',
+    to: email,
+    subject: 'Confirmação de solicitação de acesso — TryCatch',
+    react: InviteRequestConfirmationEmail({
+      name,
+      requestDate,
+      requestId,
+      appUrl: process.env.NEXT_PUBLIC_APP_URL!,
+    }),
+  });
+}

--- a/src/lib/mail/send-invite-request-email.ts
+++ b/src/lib/mail/send-invite-request-email.ts
@@ -1,4 +1,5 @@
 import { resend } from '@/lib/mail/resend';
+import { InviteRequestReceiverEmail } from '@/lib/mail/templates/invite-request-receiver';
 
 type SendInviteRequestEmailProps = {
   name: string;
@@ -15,23 +16,27 @@ export async function sendInviteRequestEmail({
 }: SendInviteRequestEmailProps) {
   const receiver = process.env.INVITE_REQUEST_RECEIVER_EMAIL;
   const sender = process.env.INVITE_REQUEST_SENDER_EMAIL;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
 
-  if (!receiver || !sender) {
+  if (!receiver || !sender || !appUrl) {
     throw new Error('Configuração de email ausente');
   }
 
-  await resend().emails.send({
+  const requestDate = new Date().toLocaleString('pt-BR');
+
+  const adminPanelLink = `${appUrl}/dashboard/admin`;
+
+  await resend.emails.send({
     from: sender,
     to: receiver,
     subject: 'Nova solicitação de acesso – TryCatch',
-    html: `
-      <h2>Nova solicitação de acesso</h2>
-      <p><strong>Nome:</strong> ${name}</p>
-      <p><strong>Email:</strong> ${email}</p>
-      <p><strong>LinkedIn:</strong> <a href="${linkedin}">${linkedin}</a></p>
-      <p><strong>Perfil solicitado:</strong> ${
-        role === 'MENTOR' ? 'Mentor' : 'Membro'
-      }</p>
-    `,
+    react: InviteRequestReceiverEmail({
+      requestDate,
+      name,
+      email,
+      linkedin,
+      adminPanelLink,
+      appUrl,
+    }),
   });
 }

--- a/src/lib/mail/templates/contact-sender.tsx
+++ b/src/lib/mail/templates/contact-sender.tsx
@@ -1,0 +1,60 @@
+import { Text, Section, Link } from '@react-email/components';
+import { EmailLayout } from './layout/layout';
+
+type ContactSenderEmailProps = {
+  name: string;
+  requestDate: string;
+  responseTimeframe: string;
+  contactId: string;
+  appUrl: string;
+};
+
+export function ContactSenderEmail({
+  name,
+  requestDate,
+  responseTimeframe,
+  contactId,
+  appUrl,
+}: ContactSenderEmailProps) {
+  return (
+    <EmailLayout title="Mensagem recebida">
+      <Text>Olá {name},</Text>
+
+      <Text>
+        Recebemos sua mensagem enviada pelo formulário de contato do TryCatch em{' '}
+        <strong>{requestDate}</strong>.
+      </Text>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Nossa equipe analisará o conteúdo e retornará em até{' '}
+          <strong>{responseTimeframe}</strong>.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Caso você não tenha enviado esta mensagem, desconsidere este email.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Protocolo da solicitação: <strong>{contactId}</strong>
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '32px', fontSize: '12px' }}>
+        <Text>
+          —
+          <br />
+          TryCatch
+          <br />
+          Plataforma colaborativa de projetos open source
+          <br />
+          <Link href={appUrl}>{appUrl}</Link>
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/src/lib/mail/templates/invite-request-confirmation.tsx
+++ b/src/lib/mail/templates/invite-request-confirmation.tsx
@@ -1,0 +1,66 @@
+import { Text, Section, Link } from '@react-email/components';
+import { EmailLayout } from './layout/layout';
+
+type InviteRequestConfirmationEmailProps = {
+  name: string;
+  requestDate: string;
+  requestId: string;
+  appUrl: string;
+};
+
+export function InviteRequestConfirmationEmail({
+  name,
+  requestDate,
+  requestId,
+  appUrl,
+}: InviteRequestConfirmationEmailProps) {
+  return (
+    <EmailLayout
+      title="Solicitação recebida com sucesso"
+      previewText="Confirmamos o recebimento da sua solicitação de acesso ao TryCatch."
+    >
+      <Text>Olá {name},</Text>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Confirmamos o recebimento da sua solicitação de acesso ao TryCatch
+          registrada em <strong>{requestDate}</strong>.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>Sua solicitação foi registrada sob o protocolo:</Text>
+
+        <Text>
+          <strong>{requestId}</strong>
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Nossa equipe analisará o pedido e você será notificado por email caso
+          seja aprovado.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Caso você não tenha realizado esta solicitação, desconsidere esta
+          mensagem.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '32px', fontSize: '12px' }}>
+        <Text>
+          —
+          <br />
+          TryCatch
+          <br />
+          Plataforma colaborativa de projetos open source
+          <br />
+          <Link href={appUrl}>{appUrl}</Link>
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/src/lib/mail/templates/invite-request-receiver.tsx
+++ b/src/lib/mail/templates/invite-request-receiver.tsx
@@ -1,0 +1,64 @@
+import { Text, Heading, Link, Section } from '@react-email/components';
+import { EmailLayout } from './layout/layout';
+
+type InviteRequestReceiverEmailProps = {
+  requestDate: string;
+  name: string;
+  email: string;
+  linkedin: string;
+  adminPanelLink: string;
+  appUrl: string;
+};
+
+export function InviteRequestReceiverEmail({
+  requestDate,
+  name,
+  email,
+  linkedin,
+  adminPanelLink,
+  appUrl,
+}: InviteRequestReceiverEmailProps) {
+  return (
+    <EmailLayout title="Nova solicitação de acesso registrada">
+      <Text>
+        Uma nova solicitação de acesso ao TryCatch foi registrada em{' '}
+        <strong>{requestDate}</strong>.
+      </Text>
+
+      <Section style={{ marginTop: '24px' }}>
+        <Text>
+          <strong>Informações do solicitante:</strong>
+        </Text>
+        <Text>Nome: {name}</Text>
+        <Text>Email: {email}</Text>
+        <Text>LinkedIn: {linkedin}</Text>
+      </Section>
+
+      <Section style={{ marginTop: '24px' }}>
+        <Text>
+          Para analisar a solicitação, acesse o painel administrativo:
+        </Text>
+        <Link href={adminPanelLink}>{adminPanelLink}</Link>
+      </Section>
+
+      <Section style={{ marginTop: '24px' }}>
+        <Text>
+          Caso considere a solicitação indevida ou inconsistente, nenhuma ação é
+          necessária.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '32px', fontSize: '12px' }}>
+        <Text>
+          —
+          <br />
+          TryCatch
+          <br />
+          Plataforma colaborativa de projetos open source
+          <br />
+          <Link href={appUrl}>{appUrl}</Link>
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/src/lib/mail/templates/invite-request-sender.tsx
+++ b/src/lib/mail/templates/invite-request-sender.tsx
@@ -1,0 +1,57 @@
+import { Text, Section, Link } from '@react-email/components';
+import { EmailLayout } from './layout/layout';
+
+type InviteRequestSenderEmailProps = {
+  name: string;
+  requestDate: string;
+  reviewTimeframe: string;
+  appUrl: string;
+};
+
+export function InviteRequestSenderEmail({
+  name,
+  requestDate,
+  reviewTimeframe,
+  appUrl,
+}: InviteRequestSenderEmailProps) {
+  return (
+    <EmailLayout title="Solicitação recebida">
+      <Text>Olá {name},</Text>
+
+      <Text>
+        Recebemos sua solicitação de acesso ao TryCatch em{' '}
+        <strong>{requestDate}</strong>.
+      </Text>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Nossa equipe analisará o pedido em até{' '}
+          <strong>{reviewTimeframe}</strong>.
+        </Text>
+
+        <Text>
+          Caso aprovado, você receberá um novo email com as instruções para
+          concluir seu cadastro.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Se você não realizou esta solicitação, desconsidere esta mensagem.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '32px', fontSize: '12px' }}>
+        <Text>
+          —
+          <br />
+          TryCatch
+          <br />
+          Plataforma colaborativa de projetos open source
+          <br />
+          <Link href={appUrl}>{appUrl}</Link>
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/src/lib/mail/templates/layout/emails-styles.tsx
+++ b/src/lib/mail/templates/layout/emails-styles.tsx
@@ -1,0 +1,66 @@
+export const bodyStyle = {
+  backgroundColor: '#EAEAEB',
+  fontFamily: 'Arial, sans-serif',
+  margin: 0,
+  padding: '40px 0',
+};
+
+export const containerStyle = {
+  backgroundColor: '#ffffff',
+  maxWidth: '600px',
+  margin: '0 auto',
+  borderRadius: '8px',
+  overflow: 'hidden' as const,
+};
+
+export const headerStyle = {
+  backgroundColor: '#101014',
+  padding: '24px',
+  textAlign: 'center' as const,
+};
+
+export const headerTitleStyle = {
+  color: '#ffffff',
+  fontSize: '20px',
+  margin: 0,
+};
+
+export const headerSubtitleStyle = {
+  color: '#A6A6AA',
+  fontSize: '12px',
+  marginTop: '4px',
+};
+
+export const contentStyle = {
+  padding: '32px',
+  color: '#35343C',
+  fontSize: '14px',
+  lineHeight: '1.6',
+};
+
+export const titleStyle = {
+  fontSize: '18px',
+  marginBottom: '16px',
+  color: '#3B38A0',
+};
+
+export const footerStyle = {
+  padding: '24px 32px',
+  textAlign: 'center' as const,
+  fontSize: '12px',
+  color: '#5C5C65',
+};
+
+export const dividerStyle = {
+  borderColor: '#EAEAEB',
+  marginBottom: '16px',
+};
+
+export const footerTextStyle = {
+  margin: '4px 0',
+};
+
+export const footerLinkStyle = {
+  color: '#3B38A0',
+  textDecoration: 'none',
+};

--- a/src/lib/mail/templates/layout/layout.tsx
+++ b/src/lib/mail/templates/layout/layout.tsx
@@ -1,0 +1,85 @@
+import {
+  Html,
+  Head,
+  Body,
+  Container,
+  Section,
+  Heading,
+  Text,
+  Link,
+  Hr,
+  Preview,
+} from '@react-email/components';
+
+import {
+  bodyStyle,
+  containerStyle,
+  headerStyle,
+  headerTitleStyle,
+  headerSubtitleStyle,
+  contentStyle,
+  titleStyle,
+  footerStyle,
+  dividerStyle,
+  footerTextStyle,
+  footerLinkStyle,
+} from './emails-styles';
+
+type EmailLayoutProps = {
+  title: string;
+  previewText?: string;
+  children: React.ReactNode;
+};
+
+export function EmailLayout({
+  title,
+  previewText,
+  children,
+}: EmailLayoutProps) {
+  return (
+    <Html>
+      <Head />
+      {previewText && <Preview>{previewText}</Preview>}
+
+      <Body style={bodyStyle}>
+        <Container style={containerStyle}>
+          <Section style={headerStyle}>
+            <Heading style={headerTitleStyle}>TryCatch</Heading>
+            <Text style={headerSubtitleStyle}>
+              Plataforma colaborativa de projetos open source
+            </Text>
+          </Section>
+
+          <Section style={contentStyle}>
+            <Heading as="h2" style={titleStyle}>
+              {title}
+            </Heading>
+
+            {children}
+          </Section>
+
+          <Section style={footerStyle}>
+            <Hr style={dividerStyle} />
+
+            <Text style={footerTextStyle}>
+              © {new Date().getFullYear()} TryCatch
+            </Text>
+
+            <Text style={footerTextStyle}>
+              Este é um email automático. Não responda a esta mensagem.
+            </Text>
+
+            <Text style={footerTextStyle}>
+              <Link
+                href={process.env.NEXT_PUBLIC_APP_URL}
+                style={footerLinkStyle}
+              >
+                {process.env.NEXT_PUBLIC_APP_URL}
+              </Link>
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/lib/mail/templates/reset-password.tsx
+++ b/src/lib/mail/templates/reset-password.tsx
@@ -1,0 +1,65 @@
+import { Text, Section, Link } from '@react-email/components';
+import { EmailLayout } from './layout/layout';
+
+type ResetPasswordEmailProps = {
+  name: string;
+  requestDate: string;
+  resetLink: string;
+  expirationTime: string;
+  appUrl: string;
+};
+
+export function ResetPasswordEmail({
+  name,
+  requestDate,
+  resetLink,
+  expirationTime,
+  appUrl,
+}: ResetPasswordEmailProps) {
+  return (
+    <EmailLayout title="Redefinição de senha">
+      <Text>Olá {name},</Text>
+
+      <Text>
+        Recebemos uma solicitação de redefinição de senha para sua conta no
+        TryCatch em <strong>{requestDate}</strong>.
+      </Text>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>Para criar uma nova senha, utilize o link abaixo:</Text>
+        <Link href={resetLink}>{resetLink}</Link>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Este link é válido por <strong>{expirationTime}</strong>.
+        </Text>
+
+        <Text>
+          Caso o prazo expire, será necessário solicitar uma nova redefinição.
+        </Text>
+      </Section>
+
+      <Section style={{ marginTop: '16px' }}>
+        <Text>
+          Se você não solicitou esta alteração, ignore este email. Sua conta
+          permanecerá inalterada.
+        </Text>
+
+        <Text>Por segurança, nunca compartilhe este link com terceiros.</Text>
+      </Section>
+
+      <Section style={{ marginTop: '32px', fontSize: '12px' }}>
+        <Text>
+          —
+          <br />
+          TryCatch
+          <br />
+          Plataforma colaborativa de projetos open source
+          <br />
+          <Link href={appUrl}>{appUrl}</Link>
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/src/tests/api/invite/invite-request-confirmation-email.test.ts
+++ b/src/tests/api/invite/invite-request-confirmation-email.test.ts
@@ -1,0 +1,34 @@
+import { sendInviteRequestConfirmationEmail } from '@/lib/mail/send-invite-request-confirmation-email';
+import { resend } from '@/lib/mail/resend';
+
+jest.mock('@/lib/mail/resend', () => ({
+  resend: {
+    emails: {
+      send: jest.fn().mockResolvedValue({ id: 'test-email-id' }),
+    },
+  },
+}));
+
+describe('sendInviteRequestConfirmationEmail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve chamar resend.emails.send com os dados corretos', async () => {
+    await sendInviteRequestConfirmationEmail({
+      name: 'User Test',
+      email: 'usertest@email.com',
+      requestDate: '01/01/2026',
+      requestId: 'abc-123',
+    });
+
+    expect(resend.emails.send).toHaveBeenCalledTimes(1);
+
+    expect(resend.emails.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'usertest@email.com',
+        subject: expect.stringContaining('Confirmação'),
+      })
+    );
+  });
+});

--- a/src/tests/api/invite/invite-request-email.test.ts
+++ b/src/tests/api/invite/invite-request-email.test.ts
@@ -1,0 +1,63 @@
+import { sendInviteRequestEmail } from '@/lib/mail/send-invite-request-email';
+import { resend } from '@/lib/mail/resend';
+
+jest.mock('@/lib/mail/resend', () => ({
+  resend: {
+    emails: {
+      send: jest.fn().mockResolvedValue({ id: 'email-test-id' }),
+    },
+  },
+}));
+
+describe('sendInviteRequestEmail', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    process.env = {
+      ...ORIGINAL_ENV,
+      INVITE_REQUEST_RECEIVER_EMAIL: 'admin@trycatch.com',
+      INVITE_REQUEST_SENDER_EMAIL: 'no-reply@trycatch.com',
+      NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+    };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('deve enviar email para o administrador com dados corretos', async () => {
+    await sendInviteRequestEmail({
+      name: 'User Teste',
+      email: 'usertest@email.com',
+      linkedin: 'https://www.linkedin.com/in/teste',
+      role: 'USER',
+    });
+
+    expect(resend.emails.send).toHaveBeenCalledTimes(1);
+
+    expect(resend.emails.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'no-reply@trycatch.com',
+        to: 'admin@trycatch.com',
+        subject: expect.stringContaining('Nova solicitação'),
+        react: expect.any(Object),
+      })
+    );
+  });
+
+  it('deve lançar erro se variáveis de ambiente estiverem ausentes', async () => {
+    process.env.INVITE_REQUEST_RECEIVER_EMAIL = '';
+    process.env.INVITE_REQUEST_SENDER_EMAIL = '';
+
+    await expect(
+      sendInviteRequestEmail({
+        name: 'User Teste',
+        email: 'usertest@email.com',
+        linkedin: 'https://www.linkedin.com/in/teste',
+        role: 'USER',
+      })
+    ).rejects.toThrow('Configuração de email ausente');
+  });
+});

--- a/src/tests/api/invite/invite-request-route.test.ts
+++ b/src/tests/api/invite/invite-request-route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from '@/app/api/invite-request/route';
+import { prisma } from '@/lib/prisma';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    inviteRequest: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/mail/send-invite-request-email', () => ({
+  sendInviteRequestEmail: jest.fn(),
+}));
+
+jest.mock('@/lib/mail/send-invite-request-confirmation-email', () => ({
+  sendInviteRequestConfirmationEmail: jest.fn(),
+}));
+
+type MockRequest = {
+  json: () => Promise<unknown>;
+};
+
+describe('POST /api/invite-request', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve criar solicitação e retornar 201', async () => {
+    (prisma.inviteRequest.findUnique as jest.Mock).mockResolvedValue(null);
+
+    (prisma.inviteRequest.create as jest.Mock).mockResolvedValue({
+      id: 'req-123',
+      status: 'PENDING',
+    });
+
+    const mockRequest: MockRequest = {
+      json: async () => ({
+        name: 'User Teste',
+        email: 'usertest@email.com',
+        linkedin: 'https://www.linkedin.com/in/teste',
+        role: 'USER',
+      }),
+    };
+
+    const response = await POST(mockRequest as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe('req-123');
+  });
+
+  it('deve retornar 409 se já existir solicitação', async () => {
+    (prisma.inviteRequest.findUnique as jest.Mock).mockResolvedValue({
+      id: 'existing-id',
+    });
+
+    const mockRequest: MockRequest = {
+      json: async () => ({
+        name: 'User Teste',
+        email: 'usertest@email.com',
+        linkedin: 'https://www.linkedin.com/in/teste',
+        role: 'USER',
+      }),
+    };
+
+    const response = await POST(mockRequest as never);
+
+    expect(response.status).toBe(409);
+  });
+
+  it('deve retornar 400 para dados inválidos', async () => {
+    const mockRequest: MockRequest = {
+      json: async () => ({
+        name: '',
+        email: 'email-invalido',
+        linkedin: 'link-errado',
+        role: 'USER',
+      }),
+    };
+
+    const response = await POST(mockRequest as never);
+
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
📩 Padronização de Emails Transacionais com React Email
🎯 Objetivo

Padronizar os emails transacionais do TryCatch utilizando React Email, removendo HTML inline e organizando a camada de envio.

📦 O que foi feito

Criação da estrutura lib/mail

Instância única do Resend

Implementação de EmailLayout reutilizável

Criação de templates React Email:

Invite (admin)

Confirmação de invite (usuário)

Reset de senha

Contato

Refatoração da rota invite-request para utilizar services

Adição de testes unitários da rota e dos services

Criação de ADR documentando a decisão arquitetural

🧠 Decisão registrada

Adoção de React Email como padrão oficial para templates transacionais.
Documento: docs/03-tecnico/adrs/adr-email-templates.md

✅ Resultado

Estrutura organizada e escalável

Separação entre template e lógica de envio

Testes cobrindo fluxo principal

Código mais consistente e manutenível

Testes ok
<img width="691" height="362" alt="Captura de tela 2026-02-25 102821" src="https://github.com/user-attachments/assets/f681dcfb-dde5-4f07-8c24-82a92841b7cc" />
