### PR TITLE
feat: display friendly role labels

### DIFF
--- a/src/app/(public)/portfolios/index.tsx
+++ b/src/app/(public)/portfolios/index.tsx
@@ -5,6 +5,7 @@ import { usePortfolios } from '@/hooks/api/usePortfolios';
 import { UserPortfolioCard } from '@/components/Portfolio/PortfolioCard';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
+import { getRoleLabel } from '@/lib/role-labels';
 
 export default function PortfolioPage() {
   const { portfolios, isLoading } = usePortfolios();
@@ -15,13 +16,18 @@ export default function PortfolioPage() {
 
     const searchLower = search.toLowerCase();
 
-    return portfolios.filter(
-      (user) =>
-        user.role.toLowerCase().includes(searchLower) ||
+    return portfolios.filter((user) => {
+      const roleLabel = getRoleLabel(user.role).toLowerCase();
+      const roleValue = user.role.toLowerCase();
+
+      return (
+        roleLabel.includes(searchLower) ||
+        roleValue.includes(searchLower) ||
         user.skills.some((skill) =>
           skill.name.toLowerCase().includes(searchLower)
         )
-    );
+      );
+    });
   }, [portfolios, search]);
 
   return (
@@ -35,7 +41,7 @@ export default function PortfolioPage() {
 
           <Input
             className="h-10 pl-10"
-            placeholder="Buscar por skill ou role"
+            placeholder="Buscar por skill ou perfil"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />

--- a/src/components/Dashboard/Charts/UsersGrowthChart.tsx
+++ b/src/components/Dashboard/Charts/UsersGrowthChart.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { apiTryCatch } from '@/lib/axios/axiosTryCatch';
 import BaseBarChart from '@/components/ui/BaseCharts/BaseBarChart';
+import { getRoleLabel } from '@/lib/role-labels';
 
 type UsersGrowthData = {
   month: string;
@@ -40,7 +41,7 @@ export default function UsersGrowthChart() {
           );
           setRoles(detectedRoles);
         }
-      } catch (err) {
+      } catch {
         setError('Erro ao carregar crescimento de usuários.');
       } finally {
         setLoading(false);
@@ -79,6 +80,7 @@ export default function UsersGrowthChart() {
       rawData={data}
       xKey="role"
       filterByMonth={true}
+      formatCategoryLabel={getRoleLabel}
       bars={[
         {
           key: 'total',

--- a/src/components/Dashboard/Invite/InviteForm/InviteForm.tsx
+++ b/src/components/Dashboard/Invite/InviteForm/InviteForm.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { apiTryCatch } from '@/lib/axios/axiosTryCatch';
+import { ROLE_OPTIONS } from '@/lib/role-labels';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -95,9 +96,9 @@ export function InviteForm() {
           )}
         </div>
 
-        {/* Role */}
+        {/* Perfil */}
         <div className="space-y-1">
-          <Label htmlFor="role">Função</Label>
+          <Label htmlFor="role">Perfil</Label>
           <Select
             value={role}
             onValueChange={(value) =>
@@ -109,9 +110,11 @@ export function InviteForm() {
             </SelectTrigger>
 
             <SelectContent>
-              <SelectItem value="USER">User</SelectItem>
-              <SelectItem value="MENTOR">Mentor</SelectItem>
-              <SelectItem value="ADMIN">Admin</SelectItem>
+              {ROLE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
 

--- a/src/components/Dashboard/Invite/InviteList/InviteList.tsx
+++ b/src/components/Dashboard/Invite/InviteList/InviteList.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { apiTryCatch } from '@/lib/axios/axiosTryCatch';
 import { AxiosError } from 'axios';
 import { CardContent } from '@/components/ui/card';
+import { getRoleLabel, ROLE_OPTIONS } from '@/lib/role-labels';
 
 const editInviteSchema = z.object({
   email: z.string().email('Email inválido'),
@@ -68,6 +69,7 @@ export function InviteList() {
     try {
       const res = await apiTryCatch.patch(`/invite/${editingId}`, {
         email: data.email,
+        role: data.role,
       });
 
       // substitui o invite atualizado na lista
@@ -158,14 +160,16 @@ export function InviteList() {
                   </div>
 
                   <div className="flex flex-col md:w-1/3">
-                    <label className="text-sm text-gray-600">Função</label>
+                    <label className="text-sm text-gray-600">Perfil</label>
                     <select
                       {...register('role')}
                       className="mt-1 w-full rounded-md border p-2 text-sm"
                     >
-                      <option value="USER">User</option>
-                      <option value="MENTOR">Mentor</option>
-                      <option value="ADMIN">Admin</option>
+                      {ROLE_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
                     </select>
                   </div>
 
@@ -197,7 +201,7 @@ export function InviteList() {
                         {invite.email}
                       </span>
                       <span className="text-sm text-gray-600">
-                        {invite.role}
+                        Perfil: {getRoleLabel(invite.role)}
                       </span>
                       <span className="text-sm text-gray-600">
                         Usado: {invite.used ? 'Sim' : 'Não'}

--- a/src/components/Dashboard/UserAdmin/EditUserAdminForm.tsx
+++ b/src/components/Dashboard/UserAdmin/EditUserAdminForm.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { ROLES, Role } from '@/lib/roles';
+import { ROLE_OPTIONS } from '@/lib/role-labels';
 
 const editUserSchema = z.object({
   name: z.string().min(1, 'Nome é obrigatório'),
@@ -172,7 +173,7 @@ export function EditUserAdminForm({ user, onSuccess, onClose }: Props) {
           </div>
 
           <div>
-            <label className="text-sm font-medium">Permissão</label>
+            <label className="text-sm font-medium">Perfil</label>
             <Select
               defaultValue={user.role}
               onValueChange={(value: 'USER' | 'ADMIN' | 'MENTOR') =>
@@ -183,9 +184,11 @@ export function EditUserAdminForm({ user, onSuccess, onClose }: Props) {
                 <SelectValue placeholder="Selecione" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="USER">Usuário</SelectItem>
-                <SelectItem value="ADMIN">Admin</SelectItem>
-                <SelectItem value="MENTOR">Mentor</SelectItem>
+                {ROLE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
             {errors.role && (

--- a/src/components/Dashboard/UserAdmin/UserAdminForm.tsx
+++ b/src/components/Dashboard/UserAdmin/UserAdminForm.tsx
@@ -22,6 +22,7 @@ import { X } from 'lucide-react';
 import { Skill } from '@prisma/client';
 import { toast } from 'sonner';
 import { ROLES, Role } from '@/lib/roles';
+import { ROLE_OPTIONS } from '@/lib/role-labels';
 
 const userAdminSchema = z.object({
   name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres'),
@@ -293,7 +294,7 @@ export function UserAdminForm() {
             </div>
 
             <div className="space-y-1">
-              <Label>Permissão</Label>
+              <Label>Perfil</Label>
               <Select
                 value={selectedRole}
                 onValueChange={(value: 'USER' | 'ADMIN' | 'MENTOR') =>
@@ -304,9 +305,11 @@ export function UserAdminForm() {
                   <SelectValue placeholder="Selecione a permissão" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="USER">Usuário</SelectItem>
-                  <SelectItem value="ADMIN">Administrador</SelectItem>
-                  <SelectItem value="MENTOR">Mentor</SelectItem>
+                  {ROLE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               {errors.role && (

--- a/src/components/Portfolio/PortfolioCard.tsx
+++ b/src/components/Portfolio/PortfolioCard.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { Github, Linkedin, Code2 } from 'lucide-react';
 import { UserPortfolioCardData } from '@/types/portfolio/portfolio-card';
+import { getRoleLabel } from '@/lib/role-labels';
 
 interface Props {
   data: UserPortfolioCardData;
@@ -70,7 +71,7 @@ export function UserPortfolioCard({ data }: Props) {
           </div>
 
           <span className="text-[11px] text-[#5C5C65] sm:text-xs">
-            {data.role}
+            {getRoleLabel(data.role)}
           </span>
         </div>
 

--- a/src/components/form/RegisterForm/UserSignupForm.tsx
+++ b/src/components/form/RegisterForm/UserSignupForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
@@ -14,12 +14,13 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { getRoleLabel } from '@/lib/role-labels';
 
 const schema = z.object({
   name: z.string().min(1, 'Nome é obrigatório'),
   email: z.string().email('Email inválido'),
   password: z.string().min(6, 'A senha deve ter no mínimo 6 caracteres'),
-  role: z.string().min(1, 'Função é obrigatória'),
+  role: z.string().min(1, 'Perfil é obrigatório'),
   linkedin: z.string().url('LinkedIn inválido').optional().or(z.literal('')),
   github: z.string().url('GitHub inválido').optional().or(z.literal('')),
   avatar: z.string(),
@@ -37,6 +38,7 @@ export default function UserSignupForm() {
     register,
     handleSubmit,
     setValue,
+    watch,
     formState: { errors, isSubmitting },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
@@ -53,6 +55,8 @@ export default function UserSignupForm() {
       inviteCode: '',
     },
   });
+
+  const selectedRole = watch('role');
 
   useEffect(() => {
     const email = searchParams.get('email');
@@ -128,7 +132,8 @@ export default function UserSignupForm() {
           </div>
 
           <div className="space-y-1">
-            <Input {...register('role')} label="Role" disabled />
+            <input type="hidden" {...register('role')} />
+            <Input label="Perfil" value={getRoleLabel(selectedRole)} disabled />
             {errors.role && (
               <p className="text-sm text-red-500">{errors.role.message}</p>
             )}

--- a/src/components/ui/BaseCharts/BaseBarChart.tsx
+++ b/src/components/ui/BaseCharts/BaseBarChart.tsx
@@ -29,6 +29,7 @@ type BaseBarChartProps = {
   layout?: 'vertical' | 'horizontal';
   height?: number;
   colors?: string[]; // NOVO: sobrescrever paleta do style guide
+  formatCategoryLabel?: (value: string) => string;
 };
 
 export default function BaseBarChart({
@@ -42,6 +43,7 @@ export default function BaseBarChart({
   height = 320,
   layout = 'horizontal',
   colors,
+  formatCategoryLabel,
 }: BaseBarChartProps) {
   const [selectedMonth, setSelectedMonth] = useState('all');
 
@@ -75,7 +77,7 @@ export default function BaseBarChart({
       const roles = Object.keys(rawData[0] ?? {}).filter((k) => k !== 'month');
 
       return roles.map((role) => ({
-        role,
+        role: formatCategoryLabel ? formatCategoryLabel(role) : role,
         total: filtered.reduce(
           (acc, item) => acc + (Number(item[role]) || 0),
           0
@@ -84,7 +86,7 @@ export default function BaseBarChart({
     }
 
     return data;
-  }, [data, rawData, selectedMonth, filterByMonth]);
+  }, [data, rawData, selectedMonth, filterByMonth, formatCategoryLabel]);
 
   return (
     <Card className="w-full" style={{ height }}>
@@ -118,7 +120,16 @@ export default function BaseBarChart({
             {/* EIXOS */}
             {layout === 'horizontal' && (
               <>
-                <XAxis dataKey={xKey} type="category" tick={{ fontSize: 12 }} />
+                <XAxis
+                  dataKey={xKey}
+                  type="category"
+                  tick={{ fontSize: 12 }}
+                  tickFormatter={(value) =>
+                    formatCategoryLabel
+                      ? formatCategoryLabel(String(value))
+                      : String(value)
+                  }
+                />
                 <YAxis type="number" tick={{ fontSize: 12 }} />
               </>
             )}
@@ -131,6 +142,11 @@ export default function BaseBarChart({
                   type="category"
                   width={100}
                   tick={{ fontSize: 12 }}
+                  tickFormatter={(value) =>
+                    formatCategoryLabel
+                      ? formatCategoryLabel(String(value))
+                      : String(value)
+                  }
                 />
               </>
             )}

--- a/src/lib/role-labels.ts
+++ b/src/lib/role-labels.ts
@@ -1,0 +1,19 @@
+import { ROLES, type Role } from '@/lib/roles';
+
+export const ROLE_LABELS: Record<Role, string> = {
+  ADMIN: 'Admin',
+  MENTOR: 'Mentor',
+  USER: 'Membro',
+};
+
+export const ROLE_OPTIONS: { value: Role; label: string }[] = [
+  { value: ROLES.USER, label: ROLE_LABELS.USER },
+  { value: ROLES.MENTOR, label: ROLE_LABELS.MENTOR },
+  { value: ROLES.ADMIN, label: ROLE_LABELS.ADMIN },
+];
+
+export function getRoleLabel(role: string | null | undefined): string {
+  if (!role) return '';
+
+  return ROLE_LABELS[role as Role] ?? role;
+}


### PR DESCRIPTION
## Descrição

Implementa labels amigáveis para perfis de usuário no frontend.

## O que foi feito

- Criado utilitário central para mapear roles:
  - ADMIN -> Admin
  - MENTOR -> Mentor
  - USER -> Membro
- Atualizadas exibições de role para usar labels amigáveis
- Substituído texto "role" por "Perfil" nas interfaces afetadas
- Mantidos os valores técnicos enviados para API sem alteração
- Atualizada busca de portfólios para considerar labels amigáveis

## Validação

- npm run lint
- npm run test
- npm run test:push
- npm run build

Fixes #333
