### PR TITLE
docs: define how-to-join participation types

### DIFF
--- a/docs/00 - governanca/documento-0-visao-geral.md
+++ b/docs/00 - governanca/documento-0-visao-geral.md
@@ -66,6 +66,7 @@ Podem evoluir conforme o produto amadurece.
 
 -   Sistema de Feedback e Reputação;
 -   Convites de Acesso;
+-   Jornada de Entrada;
 -   Gestão de Projetos;
 -   Perfis de Usuário;
 -   Permissões e Papéis;

--- a/docs/02 - produto/jornada-de-entrada-how-to-join.md
+++ b/docs/02 - produto/jornada-de-entrada-how-to-join.md
@@ -1,0 +1,319 @@
+# Documento de Produto --- Jornada de Entrada / How-to-Join
+
+Classificação: Documento de Produto / Jornada\
+Camada: 2 --- Produto\
+Status: Versão inicial baseada na issue #569
+
+------------------------------------------------------------------------
+
+## 1. Identificação
+
+-   Nome da jornada: Jornada de Entrada / How-to-Join
+-   Domínio do produto: Participação, onboarding e comunidade
+-   Documentos relacionados: Convites de Acesso; Solicitação de Convite;
+    Perfis de Usuário; Permissões e Papéis; Gestão de Projetos
+
+------------------------------------------------------------------------
+
+## 2. Contexto e Objetivo
+
+A Jornada de Entrada define, de forma institucional, as maneiras pelas
+quais uma pessoa pode participar do TryCatch.
+
+Ela existe para:
+
+-   Reduzir ambiguidade sobre como ingressar na plataforma;
+-   Diferenciar participação técnica, submissão de projetos,
+    participação como membro e atuação como mentor;
+-   Alinhar comunicação pública, fluxos de convite, permissões e
+    expectativas de responsabilidade;
+-   Apoiar textos de interface e CTAs sem alterar regras técnicas de
+    acesso ou permissões.
+
+Este documento descreve os quatro tipos oficiais de participação. Ele
+não substitui os documentos específicos de convites, perfis, permissões
+ou gestão de projetos.
+
+------------------------------------------------------------------------
+
+## 3. Tipos Oficiais de Participação
+
+O TryCatch reconhece quatro tipos oficiais de participação:
+
+1.  Contribuir com a Plataforma (Open Source)
+2.  Cadastrar um Projeto
+3.  Participar como Membro
+4.  Participar como Mentor
+
+Cada tipo deve comunicar:
+
+-   Definição clara;
+-   Público-alvo;
+-   Responsabilidades;
+-   Benefícios;
+-   Critérios básicos de entrada.
+
+------------------------------------------------------------------------
+
+## 4. Contribuir com a Plataforma (Open Source)
+
+### 4.1 Texto Institucional
+
+Participe da evolução técnica do TryCatch colaborando com código,
+documentação, testes ou melhorias de processo.
+
+### 4.2 Definição
+
+Participação voltada à melhoria da própria plataforma TryCatch como
+projeto open source.
+
+Inclui contribuições técnicas, documentação, testes, revisão de código,
+melhorias de acessibilidade, ajustes de UX, correções de bugs e apoio a
+processos de qualidade.
+
+### 4.3 Público-Alvo
+
+-   Pessoas desenvolvedoras;
+-   Designers e profissionais de UX;
+-   Pessoas interessadas em documentação técnica ou de produto;
+-   Contribuidores open source;
+-   Participantes que desejam aprender colaborando com um produto real.
+
+### 4.4 Responsabilidades
+
+-   Seguir as diretrizes de contribuição do repositório;
+-   Trabalhar a partir de issues, escopos ou discussões claras;
+-   Manter qualidade técnica, legibilidade e rastreabilidade das
+    alterações;
+-   Respeitar padrões de documentação, testes e revisão;
+-   Evitar mudanças fora do escopo aprovado.
+
+### 4.5 Benefícios
+
+-   Experiência prática com um produto real;
+-   Portfólio público de contribuições;
+-   Aprendizado sobre colaboração open source;
+-   Contato com boas práticas de engenharia, produto e documentação;
+-   Possibilidade de participar da evolução estrutural da plataforma.
+
+### 4.6 Critérios Básicos de Entrada
+
+-   Conta no GitHub;
+-   Leitura das diretrizes de contribuição;
+-   Escolha de uma issue ou melhoria com escopo claro;
+-   Capacidade de seguir o fluxo de branch, commit, pull request e
+    revisão;
+-   Respeito às decisões técnicas e de produto já documentadas.
+
+------------------------------------------------------------------------
+
+## 5. Cadastrar um Projeto
+
+### 5.1 Texto Institucional
+
+Publique sua ideia ou projeto e forme uma equipe para desenvolver de
+forma estruturada e colaborativa.
+
+### 5.2 Definição
+
+Participação voltada à proposição de um projeto real dentro da
+plataforma.
+
+A pessoa responsável cadastra uma ideia, demanda ou produto em estágio
+inicial para buscar participantes, organizar stacks, formar equipe e
+acompanhar a execução conforme as regras de Gestão de Projetos.
+
+### 5.3 Público-Alvo
+
+-   Pessoas com ideias de produto;
+-   Organizadores de projetos;
+-   Pessoas empreendedoras ou responsáveis por demandas reais;
+-   Membros da comunidade que desejam liderar uma iniciativa;
+-   Usuários que precisam estruturar uma equipe colaborativa.
+
+### 5.4 Responsabilidades
+
+-   Descrever o projeto com clareza;
+-   Informar objetivo, contexto, prazo e necessidades técnicas;
+-   Definir skills e stacks esperadas;
+-   Acompanhar a formação da equipe;
+-   Respeitar regras de edição e encerramento do projeto;
+-   Manter comunicação transparente com participantes.
+
+### 5.5 Benefícios
+
+-   Organização estruturada da ideia ou demanda;
+-   Possibilidade de formar equipe com pessoas interessadas;
+-   Registro de participação e evolução do projeto;
+-   Maior clareza sobre responsabilidades técnicas;
+-   Ambiente com regras de governança e feedback.
+
+### 5.6 Critérios Básicos de Entrada
+
+-   Ter uma ideia, demanda ou projeto minimamente descritível;
+-   Informar objetivo, descrição, prazo e stacks desejadas;
+-   Aceitar as regras de acompanhamento e encerramento do projeto;
+-   Fornecer informações suficientes para avaliação e participação;
+-   Utilizar os fluxos oficiais da plataforma para cadastro e gestão.
+
+------------------------------------------------------------------------
+
+## 6. Participar como Membro
+
+### 6.1 Texto Institucional
+
+Faça parte de equipes reais, aplique seus conhecimentos e desenvolva
+experiência prática.
+
+### 6.2 Definição
+
+Participação voltada a usuários que desejam integrar equipes de projetos
+ativos, assumir responsabilidades técnicas e desenvolver experiência
+prática em colaboração.
+
+No sistema, esta participação se relaciona ao papel padrão de usuário
+(USER), sem privilégios administrativos ou permissões de mentor.
+
+### 6.3 Público-Alvo
+
+-   Pessoas em formação ou transição de carreira;
+-   Desenvolvedores que desejam experiência prática;
+-   Profissionais que querem colaborar em projetos reais;
+-   Usuários interessados em aplicar skills específicas;
+-   Participantes que desejam construir portfólio com entregas
+    rastreáveis.
+
+### 6.4 Responsabilidades
+
+-   Manter perfil atualizado com skills, disponibilidade e informações
+    relevantes;
+-   Participar de projetos compatíveis com suas competências;
+-   Assumir tarefas de forma responsável;
+-   Comunicar impedimentos e progresso;
+-   Cumprir acordos definidos pela equipe;
+-   Respeitar feedbacks e regras de reputação.
+
+### 6.5 Benefícios
+
+-   Experiência em projetos reais;
+-   Desenvolvimento de habilidades técnicas e colaborativas;
+-   Registro de participação em portfólio;
+-   Possibilidade de receber feedback estruturado;
+-   Maior visibilidade para futuras oportunidades na comunidade.
+
+### 6.6 Critérios Básicos de Entrada
+
+-   Acesso válido à plataforma;
+-   Perfil preenchido com informações mínimas;
+-   Skills cadastradas de forma coerente;
+-   Disponibilidade compatível com a participação desejada;
+-   Aceite das regras de participação, feedback e reputação.
+
+------------------------------------------------------------------------
+
+## 7. Participar como Mentor
+
+### 7.1 Texto Institucional
+
+Apoie equipes com orientação técnica, revisão de arquitetura e
+direcionamento estratégico.
+
+### 7.2 Definição
+
+Participação voltada a pessoas com experiência suficiente para orientar
+equipes, apoiar decisões técnicas, revisar arquitetura e contribuir para
+a qualidade dos projetos.
+
+No sistema, esta participação se relaciona ao papel MENTOR, concedido
+conforme regras de convite, solicitação ou aprovação administrativa.
+
+### 7.3 Público-Alvo
+
+-   Pessoas desenvolvedoras experientes;
+-   Tech leads, arquitetos, mentores e revisores técnicos;
+-   Profissionais com experiência prática em entrega de software;
+-   Pessoas interessadas em apoiar evolução técnica de equipes;
+-   Participantes com capacidade de orientar sem assumir controle total
+    do projeto.
+
+### 7.4 Responsabilidades
+
+-   Orientar decisões técnicas com clareza e responsabilidade;
+-   Revisar arquitetura, organização de código e critérios de qualidade;
+-   Apoiar equipes sem substituir a autonomia dos membros;
+-   Sugerir melhorias compatíveis com o contexto do projeto;
+-   Respeitar limites de escopo, disponibilidade e governança;
+-   Contribuir para um ambiente colaborativo e profissional.
+
+### 7.5 Benefícios
+
+-   Possibilidade de impactar múltiplas equipes;
+-   Reconhecimento como referência técnica na comunidade;
+-   Registro de atuação como mentor;
+-   Participação em decisões de maior complexidade;
+-   Contribuição direta para maturidade dos projetos.
+
+### 7.6 Critérios Básicos de Entrada
+
+-   Acesso válido à plataforma;
+-   Perfil com experiência, skills e canais profissionais atualizados;
+-   Capacidade demonstrável de orientar tecnicamente;
+-   Aprovação de papel MENTOR conforme fluxo de governança;
+-   Compromisso com comunicação responsável e revisão construtiva.
+
+------------------------------------------------------------------------
+
+## 8. Relação com Papéis do Sistema
+
+Os tipos de participação são conceitos de produto e comunicação. Eles
+não são equivalentes diretos a todos os papéis técnicos do sistema.
+
+-   Contribuir com a Plataforma (Open Source) pode ocorrer fora do fluxo
+    autenticado da aplicação, por meio do repositório;
+-   Cadastrar um Projeto se relaciona à Gestão de Projetos e ao papel de
+    responsável pelo projeto;
+-   Participar como Membro se relaciona ao papel USER;
+-   Participar como Mentor se relaciona ao papel MENTOR;
+-   ADMIN permanece como papel operacional e administrativo, não como
+    tipo público de participação.
+
+Essa separação evita que textos institucionais exponham detalhes
+técnicos desnecessários ou confundam participação pública com permissão
+administrativa.
+
+------------------------------------------------------------------------
+
+## 9. Diretrizes de Comunicação e UX
+
+Ao aplicar estes textos em páginas, CTAs, formulários ou comunicações,
+a interface deve:
+
+-   Usar os nomes oficiais definidos neste documento;
+-   Evitar termos técnicos como role quando o contexto for público;
+-   Explicar responsabilidades antes de solicitar ação do usuário;
+-   Apresentar benefícios sem prometer aprovação automática,
+    contratação, remuneração ou vaga garantida;
+-   Preservar clareza entre contribuir com a plataforma, cadastrar um
+    projeto, participar de um projeto e atuar como mentor;
+-   Direcionar o usuário para o fluxo real disponível no produto.
+
+------------------------------------------------------------------------
+
+## 10. Critérios de Aceite
+
+Este documento atende aos critérios da issue #569 quando:
+
+-   Os quatro tipos oficiais de participação estão documentados;
+-   Cada tipo possui definição, público-alvo, responsabilidades,
+    benefícios e critérios básicos de entrada;
+-   O texto institucional base foi preservado;
+-   O documento está localizado na pasta de documentação de produto;
+-   A aplicação futura em interface respeita os fluxos e permissões já
+    documentados.
+
+------------------------------------------------------------------------
+
+## 11. Histórico
+
+Versão inicial criada para formalizar os quatro tipos oficiais de
+participação na Jornada de Entrada do TryCatch.


### PR DESCRIPTION
## Summary

- Added official documentation for the four TryCatch participation types.
- Defined description, target audience, responsibilities, benefits, and entry criteria for each type.
- Registered Jornada de Entrada in the product documentation list.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run test`
- `npm run test:push`

Closes #569