### PR TITLE
docs: add how-to-join institutional copy

### DIFF
--- a/docs/01 - estrategia/comunicacao/plano-geral-comunicacao.md
+++ b/docs/01 - estrategia/comunicacao/plano-geral-comunicacao.md
@@ -49,7 +49,8 @@ Abrange os textos públicos de apresentação do projeto:
 1.	Página inicial (Home);
 2.	Qualidade, avaliação e feedback;
 3.	Apresentação do Projeto (sobre, como funciona e para quem é);
-4.	Chamadas para ação (CTAs).
+4.	Jornada de Entrada / How-to-Join;
+5.	Chamadas para ação (CTAs).
 #### Cada seção deve possuir:
 -	Objetivo claro;
 -	Público principal e secundário;

--- a/docs/01 - estrategia/comunicacao/textos-institucionais-home.md
+++ b/docs/01 - estrategia/comunicacao/textos-institucionais-home.md
@@ -99,6 +99,8 @@ Direcionar o usuário para o próximo passo adequado, de forma clara e acessíve
 -	Empresas com projetos.
 #### Mensagem central:
 Cadastre um projeto ou faça parte da comunidade e participe de iniciativas reais.
+
+Quando a Home utilizar uma CTA ampla como "Começar", o destino recomendado é a página /how-to-join, onde o usuário pode escolher entre contribuir com a plataforma, cadastrar um projeto, participar como membro ou atuar como mentor.
 #### Atributos de qualidade a comunicar:
 -	Acessibilidade;
 -	Clareza de próximo passo.

--- a/docs/01 - estrategia/comunicacao/textos-institucionais-how-to-join.md
+++ b/docs/01 - estrategia/comunicacao/textos-institucionais-how-to-join.md
@@ -1,0 +1,267 @@
+## Documento Derivado --- Textos Institucionais: Página How-to-Join
+
+#### Classificação: Documento Derivado de Comunicação
+#### Camada: 1 --- Comunicação (derivado do Documento Estratégico --- Plano Geral de Comunicação)
+#### Status: Texto institucional proposto para validação de Marketing
+#### Documento de origem: Documento Estratégico --- Plano Geral de Comunicação
+
+________________________________________
+
+### 1. Objetivo do Documento
+
+Este documento define o texto institucional completo da página
+/how-to-join do TryCatch 4Match.
+
+A página tem como função orientar novos visitantes sobre as formas de
+participação na plataforma, com linguagem clara, institucional e
+compatível com os processos reais do produto.
+
+Este documento complementa:
+
+-   Textos Institucionais da Página Inicial (Home);
+-   Textos Institucionais: Chamadas para Ação (CTAs);
+-   Documento de Produto --- Jornada de Entrada / How-to-Join.
+
+________________________________________
+
+### 2. Princípios Aplicáveis
+
+Os textos da página /how-to-join devem obedecer aos seguintes
+princípios:
+
+-   Clareza sobre os caminhos de entrada;
+-   Neutralidade profissional;
+-   Ausência de tom promocional;
+-   Promessa sustentada por processos reais;
+-   Acessibilidade textual;
+-   Consistência com a Home, página Sobre e Jornada de Entrada;
+-   Separação clara entre contribuição open source, cadastro de projeto,
+    participação como membro e atuação como mentor.
+
+Os textos não devem prometer:
+
+-   Aprovação automática;
+-   Acesso garantido à plataforma;
+-   Participação imediata em equipe;
+-   Remuneração;
+-   Contratação;
+-   Mentoria obrigatória para todos os projetos.
+
+________________________________________
+
+### 3. Hero da Página
+
+#### Headline Principal
+
+Faça parte da construção de projetos reais e colaborativos.
+
+#### Subheadline
+
+Escolha como deseja contribuir e desenvolva experiência prática com
+organização, processos e colaboração.
+
+#### Texto de Apoio
+
+O TryCatch reúne diferentes formas de participação para quem deseja
+contribuir com a plataforma, propor projetos, integrar equipes ou apoiar
+outras pessoas como mentor. Cada caminho possui responsabilidades,
+expectativas e fluxos próprios.
+
+#### Objetivo da Seção
+
+Apresentar a proposta da página de forma direta, deixando claro que a
+entrada no TryCatch pode acontecer por diferentes caminhos.
+
+________________________________________
+
+### 4. Seção "Escolha seu Caminho"
+
+#### Texto Introdutório
+
+Cada forma de participação foi pensada para um momento diferente da
+jornada. Escolha o caminho mais alinhado ao que você deseja construir,
+aprender ou apoiar.
+
+________________________________________
+
+### 5. Modalidades de Participação
+
+#### 5.1 Contribuir com a Plataforma (Open Source)
+
+##### Descrição Objetiva
+
+Colabore com a evolução técnica do TryCatch por meio de código,
+documentação, testes, revisão ou melhorias de processo.
+
+##### Explicação do Papel
+
+Este caminho é indicado para quem deseja contribuir diretamente com o
+desenvolvimento da própria plataforma. A participação acontece no
+repositório do projeto, seguindo issues, padrões de contribuição e
+revisão por pull request.
+
+##### Expectativa de Participação
+
+Espera-se que a pessoa contribuidora escolha um escopo claro, siga as
+diretrizes do projeto, mantenha comunicação objetiva e respeite os
+padrões técnicos e documentais já definidos.
+
+##### CTA Específico
+
+Quero contribuir com o código
+
+##### Observação de Uso
+
+O CTA deve direcionar para o repositório oficial, guia de contribuição
+ou fluxo equivalente definido pela equipe.
+
+________________________________________
+
+#### 5.2 Cadastrar um Projeto
+
+##### Descrição Objetiva
+
+Apresente uma ideia, demanda ou projeto para que ele possa ser
+estruturado e desenvolvido por uma equipe colaborativa.
+
+##### Explicação do Papel
+
+Este caminho é indicado para pessoas ou organizações que possuem uma
+iniciativa real e desejam organizar sua execução dentro do TryCatch. O
+projeto deve ter objetivo, contexto, necessidades técnicas e informações
+suficientes para avaliação e formação de equipe.
+
+##### Expectativa de Participação
+
+Espera-se que a pessoa responsável descreva o projeto com clareza,
+acompanhe sua evolução, respeite as regras de gestão e mantenha
+comunicação transparente com participantes.
+
+##### CTA Específico
+
+Quero cadastrar meu projeto
+
+##### Observação de Uso
+
+O CTA deve direcionar para o fluxo real de cadastro de projetos quando
+disponível. Caso o fluxo ainda dependa de análise, o texto não deve
+prometer publicação imediata.
+
+________________________________________
+
+#### 5.3 Participar como Membro
+
+##### Descrição Objetiva
+
+Integre equipes de projetos reais, aplique suas habilidades e desenvolva
+experiência prática em colaboração.
+
+##### Explicação do Papel
+
+Este caminho é indicado para quem deseja fazer parte da comunidade e
+participar de projetos como membro de equipe. A atuação ocorre conforme
+habilidades, disponibilidade, necessidades dos projetos e regras de
+entrada da plataforma.
+
+##### Expectativa de Participação
+
+Espera-se que a pessoa mantenha seu perfil atualizado, participe de
+forma responsável, comunique disponibilidade e contribua com entregas
+compatíveis com suas habilidades.
+
+##### CTA Específico
+
+Quero participar de uma equipe
+
+##### Observação de Uso
+
+O CTA deve direcionar para o fluxo de entrada na comunidade, solicitação
+de convite ou cadastro definido pela plataforma.
+
+________________________________________
+
+#### 5.4 Participar como Mentor
+
+##### Descrição Objetiva
+
+Apoie equipes com orientação técnica, revisão de decisões e direcionamento
+para evolução dos projetos.
+
+##### Explicação do Papel
+
+Este caminho é indicado para profissionais com experiência prática que
+desejam orientar equipes, contribuir para decisões técnicas e apoiar a
+qualidade dos projetos desenvolvidos no TryCatch.
+
+##### Expectativa de Participação
+
+Espera-se que a pessoa mentora atue com clareza, responsabilidade e
+respeito à autonomia das equipes, oferecendo apoio técnico compatível com
+o contexto de cada projeto.
+
+##### CTA Específico
+
+Quero orientar equipes
+
+##### Observação de Uso
+
+O CTA deve respeitar o fluxo de solicitação ou aprovação do papel de
+mentor. O texto não deve sugerir que o papel MENTOR é concedido
+automaticamente.
+
+________________________________________
+
+### 6. Texto para Seção Detalhada
+
+#### Título Sugerido
+
+Entenda o que esperar de cada caminho
+
+#### Texto Introdutório
+
+As formas de participação não representam níveis melhores ou piores.
+Elas indicam responsabilidades diferentes dentro da plataforma. Uma
+pessoa pode começar por um caminho e, conforme sua experiência e
+disponibilidade, participar de outros fluxos no futuro.
+
+#### Bloco de Apoio
+
+O importante é escolher uma forma de entrada que esteja alinhada ao seu
+momento atual, ao que você pode contribuir e ao tipo de experiência que
+deseja desenvolver.
+
+________________________________________
+
+### 7. Diretrizes de Uso dos Textos
+
+-   Manter os nomes oficiais das quatro modalidades;
+-   Não substituir "membro" por termos técnicos como USER;
+-   Não substituir "mentor" por permissões internas sem contexto;
+-   Evitar frases como "garanta sua vaga" ou "entre agora em um
+    projeto";
+-   Usar CTAs curtos, diretos e orientados à ação;
+-   Preservar consistência com a Home, que apresenta a proposta geral, e
+    com a página Sobre, que aprofunda o funcionamento da rede.
+
+________________________________________
+
+### 8. Critérios de Aceite
+
+Este documento atende à issue #571 quando:
+
+-   A headline principal está definida;
+-   A subheadline está definida;
+-   As quatro modalidades possuem descrição objetiva;
+-   As quatro modalidades possuem explicação do papel;
+-   As quatro modalidades possuem expectativa de participação;
+-   As quatro modalidades possuem CTA específico;
+-   O texto evita tom promocional e promessas irreais;
+-   A linguagem reforça organização, colaboração e aprendizado prático;
+-   O documento está alinhado aos textos institucionais da Home.
+
+________________________________________
+
+### 9. Histórico
+
+Versão inicial criada para documentar a copy institucional da página
+/how-to-join.


### PR DESCRIPTION
## Summary

- Added institutional copy documentation for the `/how-to-join` page.
- Defined headline, subheadline, participation modality copy, expectations, and CTA texts.
- Updated communication docs to register `/how-to-join` as part of institutional communication.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run test`
- `npm run test:push`

Closes #571