### PR TITLE
feat: implement how-to-join page

### DIFF
--- a/src/app/(public)/how-to-join/page.tsx
+++ b/src/app/(public)/how-to-join/page.tsx
@@ -31,6 +31,8 @@ type ParticipationPath = {
   detail: string;
   expectation: string;
   cta: string;
+  href: string;
+  isExternal?: boolean;
   icon: ComponentType<SVGProps<SVGSVGElement>>;
 };
 
@@ -45,6 +47,8 @@ const participationPaths: ParticipationPath[] = [
     expectation:
       'Escolha um escopo claro, siga as diretrizes de contribuição e mantenha as mudanças alinhadas aos padrões do projeto.',
     cta: 'Quero contribuir com o código',
+    href: 'https://github.com/TryCatch-ForMatch/trycatch/blob/develop/CONTRIBUTING.md',
+    isExternal: true,
     icon: Code2,
   },
   {
@@ -57,6 +61,7 @@ const participationPaths: ParticipationPath[] = [
     expectation:
       'Descreva objetivo, contexto, necessidades técnicas e responsabilidades para que a equipe possa ser formada com clareza.',
     cta: 'Quero cadastrar meu projeto',
+    href: '/dashboard/team-projects/new',
     icon: FolderKanban,
   },
   {
@@ -69,6 +74,7 @@ const participationPaths: ParticipationPath[] = [
     expectation:
       'Mantenha seu perfil atualizado, comunique disponibilidade e contribua com entregas compatíveis com sua experiência.',
     cta: 'Quero participar de uma equipe',
+    href: '/invite-request?role=USER',
     icon: Handshake,
   },
   {
@@ -81,6 +87,7 @@ const participationPaths: ParticipationPath[] = [
     expectation:
       'Atue com clareza, responsabilidade e respeito à autonomia das equipes, oferecendo apoio compatível com cada contexto.',
     cta: 'Quero orientar equipes',
+    href: '/invite-request?role=MENTOR',
     icon: GraduationCap,
   },
 ];
@@ -172,8 +179,10 @@ export default function HowToJoinPage() {
                     className="h-auto min-h-11 w-full rounded-full bg-[#35343C] px-4 py-3 text-[13px] leading-[120%] text-white hover:bg-[#35343C]/90 xxl:text-[15px]"
                   >
                     <Link
-                      href={`#${path.id}`}
-                      aria-label={`${path.cta}: ver detalhes sobre ${path.title}`}
+                      href={path.href}
+                      aria-label={`${path.cta}: acessar o fluxo de ${path.title}`}
+                      target={path.isExternal ? '_blank' : undefined}
+                      rel={path.isExternal ? 'noreferrer' : undefined}
                     >
                       <span>{path.cta}</span>
                       <ArrowRight className="h-4 w-4" />

--- a/src/app/(public)/how-to-join/page.tsx
+++ b/src/app/(public)/how-to-join/page.tsx
@@ -1,0 +1,269 @@
+import type { Metadata } from 'next';
+import type { ComponentType, SVGProps } from 'react';
+import Link from 'next/link';
+import {
+  ArrowRight,
+  Code2,
+  FolderKanban,
+  GraduationCap,
+  Handshake,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export const metadata: Metadata = {
+  title: 'Como participar do TryCatch',
+  description:
+    'Conheça as formas de participar do TryCatch contribuindo com a plataforma, cadastrando projetos, participando como membro ou atuando como mentor.',
+};
+
+type ParticipationPath = {
+  id: string;
+  title: string;
+  description: string;
+  detail: string;
+  expectation: string;
+  cta: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+};
+
+const participationPaths: ParticipationPath[] = [
+  {
+    id: 'open-source',
+    title: 'Contribuir com a plataforma',
+    description:
+      'Participe da evolução técnica do TryCatch com código, documentação, testes ou melhorias de processo.',
+    detail:
+      'Este caminho é indicado para quem deseja colaborar diretamente com a própria plataforma TryCatch como projeto open source.',
+    expectation:
+      'Escolha um escopo claro, siga as diretrizes de contribuição e mantenha as mudanças alinhadas aos padrões do projeto.',
+    cta: 'Quero contribuir com o código',
+    icon: Code2,
+  },
+  {
+    id: 'cadastrar-projeto',
+    title: 'Cadastrar um projeto',
+    description:
+      'Publique sua ideia ou projeto e forme uma equipe para desenvolver de forma estruturada e colaborativa.',
+    detail:
+      'Este caminho é voltado a pessoas ou organizações que possuem uma demanda real e precisam organizar sua execução.',
+    expectation:
+      'Descreva objetivo, contexto, necessidades técnicas e responsabilidades para que a equipe possa ser formada com clareza.',
+    cta: 'Quero cadastrar meu projeto',
+    icon: FolderKanban,
+  },
+  {
+    id: 'membro',
+    title: 'Participar como membro',
+    description:
+      'Faça parte de equipes reais, aplique seus conhecimentos e desenvolva experiência prática em colaboração.',
+    detail:
+      'Este caminho é indicado para quem deseja integrar a comunidade e participar de projetos conforme suas habilidades.',
+    expectation:
+      'Mantenha seu perfil atualizado, comunique disponibilidade e contribua com entregas compatíveis com sua experiência.',
+    cta: 'Quero participar de uma equipe',
+    icon: Handshake,
+  },
+  {
+    id: 'mentor',
+    title: 'Participar como mentor',
+    description:
+      'Apoie equipes com orientação técnica, revisão de decisões e direcionamento para evolução dos projetos.',
+    detail:
+      'Este caminho é voltado a profissionais experientes que desejam orientar equipes e apoiar a qualidade técnica dos projetos.',
+    expectation:
+      'Atue com clareza, responsabilidade e respeito à autonomia das equipes, oferecendo apoio compatível com cada contexto.',
+    cta: 'Quero orientar equipes',
+    icon: GraduationCap,
+  },
+];
+
+export default function HowToJoinPage() {
+  return (
+    <main className="px-5 py-5 md:px-7 lg:px-6 xl:px-10 xxl:px-[39px]">
+      <section
+        aria-labelledby="how-to-join-title"
+        className="mx-auto max-w-[1280px] rounded-2xl bg-[#EAEAEB] px-6 py-12 md:px-10 md:py-16 lg:px-16 lg:py-20 xxl:px-24 xxl:py-28"
+      >
+        <div className="max-w-[820px]">
+          <p className="text-[12px] leading-[140%] font-medium tracking-normal text-[#3B38A0] md:text-[14px] xxl:text-[16px]">
+            Jornada de entrada
+          </p>
+
+          <h1
+            id="how-to-join-title"
+            className="mt-4 text-[30px] leading-[120%] font-medium tracking-normal text-[#35343C] md:text-[48px] lg:text-[56px] xxl:text-[72px]"
+          >
+            Como participar do TryCatch
+          </h1>
+
+          <p className="mt-6 max-w-[760px] text-[16px] leading-[150%] text-[#5C5C65] md:text-[18px] xxl:text-[22px]">
+            Escolha como deseja contribuir e desenvolva experiência prática com
+            organização, processos e colaboração.
+          </p>
+
+          <p className="mt-5 max-w-[760px] text-[14px] leading-[150%] text-[#5C5C65] md:text-[16px] xxl:text-[18px]">
+            O TryCatch reúne diferentes formas de participação para quem deseja
+            contribuir com a plataforma, propor projetos, integrar equipes ou
+            apoiar outras pessoas como mentor.
+          </p>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="choose-path-title"
+        className="mx-auto mt-16 max-w-[1280px] md:mt-24 xxl:mt-32"
+      >
+        <div className="grid gap-5 lg:grid-cols-12">
+          <div className="lg:col-start-2 lg:col-end-8">
+            <h2
+              id="choose-path-title"
+              className="text-[26px] leading-[120%] font-medium tracking-normal text-[#35343C] md:text-[44px] xxl:text-[64px]"
+            >
+              Escolha seu caminho
+            </h2>
+
+            <p className="mt-5 max-w-[720px] text-[14px] leading-[150%] text-[#5C5C65] md:text-[16px] xxl:text-[18px]">
+              Cada forma de participação foi pensada para um momento diferente
+              da jornada. Compare as opções e avance pelo caminho mais alinhado
+              ao que você deseja construir, aprender ou apoiar.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-4 xxl:gap-6">
+          {participationPaths.map((path) => {
+            const Icon = path.icon;
+
+            return (
+              <Card
+                key={path.id}
+                className="min-h-[360px] justify-between rounded-2xl border-0 bg-white px-0 py-0 shadow-none ring-1 ring-[#EAEAEB] transition-colors hover:ring-[#D9D9ED]"
+              >
+                <CardHeader className="gap-5 px-6 pt-6">
+                  <span
+                    aria-hidden
+                    className="flex h-12 w-12 items-center justify-center rounded-full bg-[#D9D9ED] text-[#3B38A0]"
+                  >
+                    <Icon className="h-6 w-6" />
+                  </span>
+
+                  <CardTitle className="text-[20px] leading-[120%] font-medium tracking-normal text-[#35343C] xxl:text-[24px]">
+                    {path.title}
+                  </CardTitle>
+                </CardHeader>
+
+                <CardContent className="max-h-none overflow-visible px-6">
+                  <p className="text-[14px] leading-[150%] text-[#5C5C65] md:text-[15px] xxl:text-[16px]">
+                    {path.description}
+                  </p>
+                </CardContent>
+
+                <CardFooter className="px-6 pb-6">
+                  <Button
+                    asChild
+                    className="h-auto min-h-11 w-full rounded-full bg-[#35343C] px-4 py-3 text-[13px] leading-[120%] text-white hover:bg-[#35343C]/90 xxl:text-[15px]"
+                  >
+                    <Link
+                      href={`#${path.id}`}
+                      aria-label={`${path.cta}: ver detalhes sobre ${path.title}`}
+                    >
+                      <span>{path.cta}</span>
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                </CardFooter>
+              </Card>
+            );
+          })}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="details-title"
+        className="mx-auto mt-16 max-w-[1280px] md:mt-24 xxl:mt-32"
+      >
+        <div className="grid gap-10 lg:grid-cols-12">
+          <div className="lg:col-start-2 lg:col-end-6">
+            <h2
+              id="details-title"
+              className="text-[26px] leading-[120%] font-medium tracking-normal text-[#35343C] md:text-[44px] xxl:text-[64px]"
+            >
+              Entenda o que esperar de cada caminho
+            </h2>
+
+            <p className="mt-5 text-[14px] leading-[150%] text-[#5C5C65] md:text-[16px] xxl:text-[18px]">
+              As formas de participação indicam responsabilidades diferentes
+              dentro da plataforma. Escolha uma forma de entrada alinhada ao seu
+              momento atual e ao tipo de experiência que deseja desenvolver.
+            </p>
+          </div>
+
+          <div className="space-y-4 lg:col-start-6 lg:col-end-12">
+            {participationPaths.map((path) => {
+              const Icon = path.icon;
+
+              return (
+                <article
+                  key={path.id}
+                  id={path.id}
+                  className="scroll-mt-28 rounded-2xl bg-[#F8F8FA] p-6 md:p-8"
+                >
+                  <div className="flex items-start gap-4">
+                    <span
+                      aria-hidden
+                      className="mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#3B38A0] text-white"
+                    >
+                      <Icon className="h-5 w-5" />
+                    </span>
+
+                    <div>
+                      <h3 className="text-[20px] leading-[120%] font-medium tracking-normal text-[#35343C] md:text-[24px] xxl:text-[30px]">
+                        {path.title}
+                      </h3>
+
+                      <p className="mt-3 text-[14px] leading-[150%] text-[#5C5C65] md:text-[16px]">
+                        {path.detail}
+                      </p>
+
+                      <p className="mt-3 text-[14px] leading-[150%] text-[#5C5C65] md:text-[16px]">
+                        {path.expectation}
+                      </p>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="future-faq-title"
+        className="mx-auto mt-16 max-w-[1280px] md:mt-24 xxl:mt-32"
+      >
+        <div className="rounded-2xl bg-[#D9D9ED] px-6 py-8 md:px-10 md:py-10 lg:px-16">
+          <h2
+            id="future-faq-title"
+            className="text-[22px] leading-[120%] font-medium tracking-normal text-[#35343C] md:text-[32px] xxl:text-[44px]"
+          >
+            Dúvidas frequentes
+          </h2>
+
+          <p className="mt-4 max-w-[760px] text-[14px] leading-[150%] text-[#5C5C65] md:text-[16px] xxl:text-[18px]">
+            Esta página está preparada para receber uma seção de perguntas
+            frequentes sobre convites, projetos, participação como membro e
+            atuação como mentor conforme a jornada evoluir.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(public)/invite-request/page.tsx
+++ b/src/app/(public)/invite-request/page.tsx
@@ -1,6 +1,23 @@
 import { InviteRequestForm } from '@/components/form/InviteRequest/InviteRequestForm';
 
-export default function InviteRequestPage() {
+type InviteRequestPageProps = {
+  searchParams?: Promise<{
+    role?: string | string[];
+  }>;
+};
+
+function getDefaultRole(role?: string | string[]) {
+  const value = Array.isArray(role) ? role[0] : role;
+
+  return value === 'MENTOR' ? 'MENTOR' : 'USER';
+}
+
+export default async function InviteRequestPage({
+  searchParams,
+}: InviteRequestPageProps) {
+  const params = await searchParams;
+  const defaultRole = getDefaultRole(params?.role);
+
   return (
     <main className="flex min-h-screen flex-col">
       <section className="flex flex-1 items-center justify-center px-5 py-10 md:px-7 lg:px-6 xl:px-10">
@@ -24,7 +41,7 @@ export default function InviteRequestPage() {
             </p>
           </header>
 
-          <InviteRequestForm />
+          <InviteRequestForm defaultRole={defaultRole} />
         </div>
       </section>
     </main>

--- a/src/components/form/InviteRequest/InviteRequestForm.tsx
+++ b/src/components/form/InviteRequest/InviteRequestForm.tsx
@@ -28,7 +28,13 @@ const inviteRequestSchema = z.object({
 
 type InviteRequestFormData = z.infer<typeof inviteRequestSchema>;
 
-export function InviteRequestForm() {
+type InviteRequestFormProps = {
+  defaultRole?: InviteRequestFormData['role'];
+};
+
+export function InviteRequestForm({
+  defaultRole = 'USER',
+}: InviteRequestFormProps) {
   const [loading, setLoading] = useState(false);
 
   const {
@@ -38,6 +44,9 @@ export function InviteRequestForm() {
     formState: { errors },
   } = useForm<InviteRequestFormData>({
     resolver: zodResolver(inviteRequestSchema),
+    defaultValues: {
+      role: defaultRole,
+    },
   });
 
   async function onSubmit(data: InviteRequestFormData) {


### PR DESCRIPTION
## Summary

- Implemented the public `/how-to-join` page.
- Added intro, participation cards, detailed explanation sections, and future FAQ placeholder.
- Reused existing `Button` and `Card` UI components with responsive and accessible structure.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run test:push`
- Local route `/how-to-join` returns 200

Closes #572
Closes #573