### PR TITLE
docs: add informational educational content

### DIFF
--- a/docs/00 - governanca/documento-0-visao-geral.md
+++ b/docs/00 - governanca/documento-0-visao-geral.md
@@ -70,6 +70,7 @@ Podem evoluir conforme o produto amadurece.
 -   Gestão de Projetos;
 -   Perfis de Usuário;
 -   Permissões e Papéis;
+-   Conteúdos Informativos e Educacionais;
 -   Painel Administrativo.
 
 ### Camada 3 --- Documentos Técnicos (Evolutivos)

--- a/docs/01 - estrategia/comunicacao/plano-geral-comunicacao.md
+++ b/docs/01 - estrategia/comunicacao/plano-geral-comunicacao.md
@@ -64,6 +64,10 @@ Incluem:
 -	Glossário, quando necessário.
 
 Esses conteúdos têm papel educativo e de suporte ao usuário.
+
+O documento de produto `docs/02 - produto/conteudos/conteudos-informativos-e-educacionais.md`
+detalha a estrutura inicial, critérios de qualidade e regras de revisão
+desses conteúdos.
 ________________________________________
 #### 5.3 Comunicação Transacional (Sistema)
 Refere-se a textos utilizados em fluxos automáticos do sistema, como:
@@ -140,6 +144,7 @@ Este documento orienta diretamente:
 #### Ele deve ser utilizado em conjunto com:
 -	Documento Estratégico de Marca;
 -	Documento Estratégico — Acessibilidade e Inclusão Digital;
+-	Documento de Produto — Conteúdos Informativos e Educacionais;
 -	Documento 0 — Visão Geral, Governança e Arquitetura da Documentação.
 ________________________________________
 ### 10. Evolução do Documento
@@ -154,5 +159,6 @@ ________________________________________
 -	Separação entre comunicação institucional, transacional e interna;
 -	Tratamento de textos como parte da qualidade do produto.
 -   Inclusão de comunicação externa (mídia e redes sociais) como eixo estratégico independente.
+-   Formalização de conteúdos informativos e educacionais como documento de produto.
 ________________________________________
 Observação: Este documento está alinhado ao Documento 0 — Visão Geral, Governança e Arquitetura da Documentação.

--- a/docs/02 - produto/conteudos/conteudos-informativos-e-educacionais.md
+++ b/docs/02 - produto/conteudos/conteudos-informativos-e-educacionais.md
@@ -1,0 +1,254 @@
+# Documento de Produto - Conteúdos Informativos e Educacionais
+
+**Classificação:** Documento de Produto / Conteúdo  
+**Camada:** 2 - Documentos de Produto e Funcionalidades  
+**Status:** Documento inicial consolidado
+
+------------------------------------------------------------------------
+
+## 1. Objetivo
+
+Este documento define a estrutura dos conteúdos informativos e
+educacionais da plataforma TryCatch.
+
+Esses conteúdos existem para orientar usuários, reduzir dúvidas
+recorrentes e explicar regras da plataforma de forma clara, acessível e
+consistente.
+
+------------------------------------------------------------------------
+
+## 2. Contexto
+
+A plataforma possui diferentes perfis de usuário, jornadas de entrada e
+fluxos de participação. Sem conteúdo de apoio, usuários podem ter
+dificuldade para entender:
+
+- Como participar da comunidade;
+- Como funcionam projetos, convites e papéis;
+- Quais regras devem ser seguidas;
+- Onde encontrar ajuda antes de abrir uma solicitação;
+- Quais limites existem entre colaboração, mentoria e execução de
+  projetos.
+
+O conteúdo informativo atua como suporte de produto e comunicação
+institucional.
+
+------------------------------------------------------------------------
+
+## 3. Tipos de Conteúdo
+
+### 3.1 Perguntas frequentes
+
+A FAQ deve responder dúvidas comuns com linguagem direta.
+
+Temas prioritários:
+
+- Como participar do TryCatch;
+- Diferença entre contribuir, cadastrar projeto, participar como membro
+  e participar como mentor;
+- Como funciona o convite de acesso;
+- Como publicar ou revisar um portfólio;
+- Como projetos são cadastrados e avaliados;
+- Como feedback e reputação são tratados;
+- Como entrar em contato em caso de dúvida.
+
+### 3.2 Explicações sobre processos internos
+
+Devem explicar fluxos da plataforma em etapas simples.
+
+Processos iniciais:
+
+- Jornada de entrada;
+- Solicitação de convite;
+- Cadastro e revisão de projeto;
+- Formação de equipe;
+- Participação em projeto;
+- Registro de feedback;
+- Atualização de portfólio;
+- Solicitação de mentoria.
+
+### 3.3 Regras da plataforma
+
+Devem deixar claro o comportamento esperado de membros, mentores,
+administradores e visitantes.
+
+Regras iniciais:
+
+- Manter informações de perfil e portfólio verdadeiras;
+- Respeitar a privacidade de outras pessoas;
+- Não publicar dados sensíveis;
+- Não usar a plataforma para promessas de contratação garantida;
+- Tratar feedback como instrumento de melhoria;
+- Comunicar riscos, indisponibilidade ou bloqueios com clareza;
+- Seguir o fluxo oficial de contribuição quando alterar código ou
+  documentação.
+
+### 3.4 Glossário
+
+O glossário deve ser usado quando conceitos da plataforma puderem gerar
+interpretações diferentes.
+
+Termos iniciais:
+
+| Termo | Definição |
+| --- | --- |
+| Membro | Pessoa que participa de projetos ou contribui com a plataforma. |
+| Mentor | Pessoa que orienta membros ou equipes com experiência técnica ou estratégica. |
+| Projeto | Iniciativa cadastrada para colaboração ou execução estruturada. |
+| Portfólio | Perfil público com dados profissionais, projetos, habilidades e visibilidade controlada. |
+| Feedback | Avaliação vinculada a projeto ou colaboração realizada. |
+| Convite | Mecanismo de entrada usado para liberar cadastro ou participação. |
+
+------------------------------------------------------------------------
+
+## 4. Estrutura Recomendada
+
+Cada conteúdo informativo deve seguir uma estrutura mínima.
+
+### 4.1 Pergunta frequente
+
+- Pergunta:
+- Resposta curta:
+- Quando isso se aplica:
+- Link relacionado:
+- Responsável por revisão:
+
+### 4.2 Explicação de processo
+
+- Nome do processo:
+- Objetivo:
+- Quem participa:
+- Etapas:
+- Resultado esperado:
+- Regras associadas:
+- Erros comuns:
+- Links relacionados:
+
+### 4.3 Regra da plataforma
+
+- Nome da regra:
+- Descrição:
+- Quem deve seguir:
+- Motivo:
+- Exemplo permitido:
+- Exemplo não permitido:
+- Consequência em caso de violação:
+
+------------------------------------------------------------------------
+
+## 5. Critérios de Qualidade
+
+Todo conteúdo informativo deve:
+
+- Ser claro para pessoas iniciantes;
+- Usar frases curtas e objetivas;
+- Evitar termos técnicos sem contexto;
+- Explicar apenas processos reais da plataforma;
+- Manter consistência com documentos de produto e técnicos;
+- Indicar links relacionados quando existirem;
+- Evitar promessas que a plataforma não garante;
+- Respeitar privacidade, acessibilidade e inclusão.
+
+------------------------------------------------------------------------
+
+## 6. Governança
+
+### Responsáveis
+
+- Produto define escopo, regras e prioridade do conteúdo.
+- Comunicação revisa clareza, tom e consistência.
+- Engenharia valida aderência ao comportamento real do sistema.
+- Comunidade pode sugerir novas perguntas e melhorias.
+
+### Ciclo de revisão
+
+1. Identificar dúvida recorrente ou regra pouco clara.
+2. Validar se o tema já existe na documentação.
+3. Criar ou atualizar conteúdo seguindo a estrutura recomendada.
+4. Conferir consistência com documentos relacionados.
+5. Revisar linguagem e acessibilidade.
+6. Publicar alteração via pull request.
+
+------------------------------------------------------------------------
+
+## 7. Relação com Produto
+
+Conteúdos informativos devem apoiar, mas não substituir, documentos de
+produto.
+
+Documentos relacionados:
+
+- `docs/01 - estrategia/comunicacao/plano-geral-comunicacao.md`
+- `docs/02 - produto/jornada-de-entrada-how-to-join.md`
+- `docs/02 - produto/jornada-de-entrada-how-to-join-ux.md`
+- `docs/02 - produto/convite/invite-request.md`
+- `docs/02 - produto/projetos/gestao-projetos.md`
+- `docs/02 - produto/portfolio/portfolio.md`
+- `docs/02 - produto/feedback/feedback-reputacao.md`
+- `docs/02 - produto/permissoes-papeis/permissoes.md`
+
+------------------------------------------------------------------------
+
+## 8. Conteúdos Iniciais
+
+### FAQ inicial
+
+| Pergunta | Resposta |
+| --- | --- |
+| Como posso participar do TryCatch? | A pessoa pode contribuir com a plataforma, cadastrar um projeto, participar como membro ou atuar como mentor. |
+| Preciso ter experiência avançada para participar? | Não. A participação pode acontecer em diferentes níveis de experiência, desde que as responsabilidades estejam claras. |
+| Posso cadastrar um projeto externo? | Sim, desde que o projeto seja descrito com objetivo, escopo, responsabilidades, critérios de participação e informações de contato. |
+| O portfólio é público por padrão? | Sim, mas o usuário pode controlar a visibilidade do portfólio e de campos específicos. |
+| Feedback fica visível para qualquer visitante? | Apenas quando a configuração de visibilidade permitir. O sistema deve preservar rastreabilidade no backend. |
+
+### Processos internos iniciais
+
+| Processo | Explicação curta |
+| --- | --- |
+| Entrada na plataforma | A pessoa escolhe a forma de participação e segue o fluxo mais adequado ao seu objetivo. |
+| Convite | O convite libera acesso ou participação conforme regras definidas pela plataforma. |
+| Cadastro de projeto | A proposta deve informar objetivo, escopo, responsabilidades, tecnologias e critérios de participação. |
+| Formação de equipe | Membros são conectados a projetos considerando necessidades, habilidades e disponibilidade. |
+| Feedback | Avaliações devem ser relacionadas a colaboração real e usadas para melhoria contínua. |
+
+### Regras iniciais
+
+| Regra | Aplicação |
+| --- | --- |
+| Dados reais | Perfis, portfólios e projetos devem usar informações verdadeiras e verificáveis. |
+| Privacidade | Dados pessoais, credenciais e informações sensíveis não devem ser publicados. |
+| Clareza de responsabilidade | Cada projeto deve indicar o que precisa ser feito e quem participa. |
+| Respeito entre participantes | Comunicação deve ser profissional, objetiva e respeitosa. |
+| Contribuição rastreável | Alterações em código ou documentação devem seguir o fluxo oficial de pull request. |
+
+------------------------------------------------------------------------
+
+## 9. Antipadrões Evitados
+
+- Criar respostas genéricas que não explicam o processo real;
+- Usar linguagem promocional em vez de orientação prática;
+- Repetir conteúdo técnico sem adaptar para o usuário final;
+- Publicar regras sem motivo ou consequência clara;
+- Manter FAQ desatualizada em relação ao comportamento do sistema;
+- Misturar documentação interna com comunicação pública sem contexto.
+
+------------------------------------------------------------------------
+
+## 10. Critérios de Aceite
+
+- FAQ inicial documentada.
+- Processos internos principais documentados.
+- Regras da plataforma documentadas.
+- Estrutura de criação e revisão definida.
+- Relação com documentos existentes registrada.
+- Conteúdo alinhado ao Plano Geral de Comunicação.
+
+------------------------------------------------------------------------
+
+## 11. Próximos Passos
+
+- Transformar os conteúdos aprovados em páginas públicas quando houver
+  decisão de produto.
+- Revisar a FAQ da Home para manter consistência com este documento.
+- Criar glossário ampliado conforme novos termos surgirem.
+- Definir responsável por revisão periódica dos conteúdos.


### PR DESCRIPTION
## Summary

- Added a product documentation page for informational and educational content.
- Documented FAQ guidance, internal process explanations, platform rules, glossary terms, governance, and review criteria.
- Linked the new document from the communication plan and Documento 0 documentation structure.

## Validation

- `git diff --check`
- `npm run lint`
- `npm run test:push`
- `npm run build`

Closes #490