### PR TITLE
test: add invite domain unit tests

### DIFF
--- a/src/tests/api/invite/invite-id-route.test.ts
+++ b/src/tests/api/invite/invite-id-route.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment node
+ */
+
+import { DELETE, GET, PATCH } from '@/app/api/invite/[id]/route';
+import { checkAuth } from '@/lib/check-auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    invite: {
+      delete: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+type MockRequest = {
+  json?: () => Promise<unknown>;
+  nextUrl: {
+    pathname: string;
+  };
+};
+
+const createRequest = (id = 'invite-1', body?: unknown) =>
+  ({
+    nextUrl: {
+      pathname: `/api/invite/${id}`,
+    },
+    json: body === undefined ? undefined : async () => body,
+  }) as MockRequest as NextRequest;
+
+const authorizeAdmin = () => {
+  (checkAuth as jest.Mock).mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: 'admin-1', role: 'ADMIN' },
+    },
+  });
+};
+
+describe('GET /api/invite/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve retornar convite pelo id', async () => {
+    const invite = {
+      id: 'invite-1',
+      email: 'member@example.com',
+      code: 'abc123',
+      role: 'USER',
+      used: false,
+    };
+
+    (prisma.invite.findUnique as jest.Mock).mockResolvedValue(invite);
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(invite);
+    expect(prisma.invite.findUnique).toHaveBeenCalledWith({
+      where: { id: 'invite-1' },
+    });
+  });
+
+  it('deve retornar 404 quando convite não existir', async () => {
+    (prisma.invite.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(createRequest('missing-id'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+});
+
+describe('PATCH /api/invite/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve atualizar email e role do convite', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.invite.update as jest.Mock).mockResolvedValue({
+      id: 'invite-1',
+      email: 'updated@example.com',
+      role: 'MENTOR',
+      code: 'abc123',
+      used: false,
+    });
+
+    const response = await PATCH(
+      createRequest('invite-1', {
+        email: 'updated@example.com',
+        role: 'MENTOR',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.email).toBe('updated@example.com');
+    expect(body.role).toBe('MENTOR');
+    expect(prisma.invite.update).toHaveBeenCalledWith({
+      where: { id: 'invite-1' },
+      data: {
+        email: 'updated@example.com',
+        role: 'MENTOR',
+      },
+    });
+  });
+
+  it('deve retornar 400 quando body não tiver email ou role', async () => {
+    const response = await PATCH(
+      createRequest('invite-1', {
+        email: 'updated@example.com',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.invite.update).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando email já estiver em outro convite', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue({
+      id: 'invite-2',
+      email: 'taken@example.com',
+    });
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await PATCH(
+      createRequest('invite-1', {
+        email: 'taken@example.com',
+        role: 'USER',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.invite.findFirst).toHaveBeenCalledWith({
+      where: {
+        email: 'taken@example.com',
+        NOT: { id: 'invite-1' },
+      },
+    });
+    expect(prisma.invite.update).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando email já pertencer a usuário', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+    });
+
+    const response = await PATCH(
+      createRequest('invite-1', {
+        email: 'user@example.com',
+        role: 'USER',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.invite.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/invite/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve deletar convite pelo id', async () => {
+    (prisma.invite.delete as jest.Mock).mockResolvedValue({
+      id: 'invite-1',
+    });
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ message: 'Convite deletado com sucesso.' });
+    expect(prisma.invite.delete).toHaveBeenCalledWith({
+      where: { id: 'invite-1' },
+    });
+  });
+});

--- a/src/tests/api/invite/invite-route.test.ts
+++ b/src/tests/api/invite/invite-route.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET, POST } from '@/app/api/invite/route';
+import { GET as GET_COUNT } from '@/app/api/invite/count/route';
+import { checkAuth } from '@/lib/check-auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    invite: {
+      count: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+    user: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+type MockRequest = {
+  json: () => Promise<unknown>;
+};
+
+const authorizeAdmin = () => {
+  (checkAuth as jest.Mock).mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: 'admin-1', role: 'ADMIN' },
+    },
+  });
+};
+
+describe('GET /api/invite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve listar convites em ordem alfabética por email', async () => {
+    const invites = [
+      {
+        id: 'invite-1',
+        email: 'ana@example.com',
+        code: 'code-1',
+        role: 'USER',
+        used: false,
+      },
+    ];
+
+    (prisma.invite.findMany as jest.Mock).mockResolvedValue(invites);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(invites);
+    expect(prisma.invite.findMany).toHaveBeenCalledWith({
+      orderBy: { email: 'asc' },
+    });
+  });
+
+  it('deve bloquear listagem para usuário não autorizado', async () => {
+    const authResponse = Response.json(
+      { error: 'Acesso negado.' },
+      {
+        status: 403,
+      }
+    );
+
+    (checkAuth as jest.Mock).mockResolvedValue({
+      authorized: false,
+      response: authResponse,
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    expect(prisma.invite.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/invite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve criar convite quando email e role forem válidos', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.invite.create as jest.Mock).mockImplementation(({ data }) =>
+      Promise.resolve({
+        id: 'invite-1',
+        email: data.email,
+        code: data.code,
+        role: data.role,
+        used: false,
+      })
+    );
+
+    const request: MockRequest = {
+      json: async () => ({
+        email: 'newuser@example.com',
+        role: 'USER',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({
+      email: 'newuser@example.com',
+      code: expect.any(String),
+      role: 'USER',
+    });
+    expect(body.data.code).toHaveLength(16);
+    expect(prisma.invite.create).toHaveBeenCalledWith({
+      data: {
+        email: 'newuser@example.com',
+        code: expect.any(String),
+        role: 'USER',
+      },
+    });
+  });
+
+  it('deve retornar 400 quando payload for inválido', async () => {
+    const request: MockRequest = {
+      json: async () => ({
+        email: 'invalid-email',
+        role: 'USER',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.invite.create).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando já existir convite para o email', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue({
+      id: 'invite-existing',
+      email: 'existing@example.com',
+    });
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const request: MockRequest = {
+      json: async () => ({
+        email: 'existing@example.com',
+        role: 'USER',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.invite.create).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando já existir usuário com o email', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.user.findFirst as jest.Mock).mockResolvedValue({
+      id: 'user-existing',
+      email: 'existing-user@example.com',
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        email: 'existing-user@example.com',
+        role: 'MENTOR',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.invite.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/invite/count', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve contar apenas convites não utilizados', async () => {
+    (prisma.invite.count as jest.Mock).mockResolvedValue(3);
+
+    const response = await GET_COUNT();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ count: 3 });
+    expect(prisma.invite.count).toHaveBeenCalledWith({
+      where: { used: false },
+    });
+  });
+});

--- a/src/tests/api/invite/invite-validation.test.ts
+++ b/src/tests/api/invite/invite-validation.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST as VALIDATE_INVITE } from '@/app/api/auth/register/route';
+import { POST as SIGNUP } from '@/app/api/auth/signup/route';
+import { prisma } from '@/lib/prisma';
+import { hash } from 'bcryptjs';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    invite: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(),
+}));
+
+type MockRequest = {
+  json: () => Promise<unknown>;
+};
+
+describe('POST /api/auth/register', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve validar convite ativo para email e código informados', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue({
+      id: 'invite-1',
+      email: 'member@example.com',
+      code: 'valid-code',
+      role: 'USER',
+      used: false,
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        email: 'member@example.com',
+        inviteCode: 'valid-code',
+      }),
+    };
+
+    const response = await VALIDATE_INVITE(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({
+      email: 'member@example.com',
+      role: 'USER',
+      code: 'valid-code',
+    });
+    expect(prisma.invite.findFirst).toHaveBeenCalledWith({
+      where: {
+        email: 'member@example.com',
+        code: 'valid-code',
+        used: false,
+      },
+    });
+  });
+
+  it('deve retornar 403 quando convite for inválido ou já utilizado', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const request: MockRequest = {
+      json: async () => ({
+        email: 'member@example.com',
+        inviteCode: 'used-code',
+      }),
+    };
+
+    const response = await VALIDATE_INVITE(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.success).toBe(false);
+  });
+});
+
+describe('POST /api/auth/signup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve criar usuário e marcar convite como usado', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue({
+      id: 'invite-1',
+      email: 'member@example.com',
+      code: 'valid-code',
+      role: 'MENTOR',
+      used: false,
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    (hash as jest.Mock).mockResolvedValue('hashed-password');
+    (prisma.user.create as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      name: 'Member Test',
+      email: 'member@example.com',
+      role: 'MENTOR',
+    });
+    (prisma.invite.update as jest.Mock).mockResolvedValue({
+      id: 'invite-1',
+      used: true,
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'Member Test',
+        email: 'member@example.com',
+        password: 'secret123',
+        avatar: '',
+        linkedin: '',
+        github: '',
+        bio: 'Backend developer',
+        inviteCode: 'valid-code',
+      }),
+    };
+
+    const response = await SIGNUP(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({
+      id: 'user-1',
+      name: 'Member Test',
+      email: 'member@example.com',
+      role: 'MENTOR',
+    });
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: {
+        name: 'Member Test',
+        email: 'member@example.com',
+        password: 'hashed-password',
+        avatar: '',
+        linkedin: '',
+        github: '',
+        bio: 'Backend developer',
+        role: 'MENTOR',
+      },
+    });
+    expect(prisma.invite.update).toHaveBeenCalledWith({
+      where: { id: 'invite-1' },
+      data: { used: true },
+    });
+  });
+
+  it('deve retornar 403 quando convite de cadastro for inválido ou já utilizado', async () => {
+    (prisma.invite.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'Member Test',
+        email: 'member@example.com',
+        password: 'secret123',
+        avatar: '',
+        linkedin: '',
+        github: '',
+        bio: 'Backend developer',
+        inviteCode: 'used-code',
+      }),
+    };
+
+    const response = await SIGNUP(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.success).toBe(false);
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.invite.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Added unit tests for the Invite domain.
- Covered invite listing, creation, duplicate email handling, invalid payloads, count, lookup, update conflicts, and deletion.
- Added invite validation tests for register and signup flows, including invalid or already used invite scenarios.
- Mocked Prisma, auth, and password hashing to keep tests isolated.

## Validation

- `npm run test -- src/tests/api/invite`
- `npm run lint`
- `npm run test:push`
- `npx jest --coverage --coverageThreshold='{"global":{"branches":60,"functions":60,"lines":60,"statements":60}}'`
- `git diff --check`
- `npm run build`

Closes #533