### PR TITLE
test: add skill and tech stack unit tests

### DIFF
--- a/src/tests/api/skill/skill-id-route.test.ts
+++ b/src/tests/api/skill/skill-id-route.test.ts
@@ -1,0 +1,243 @@
+/**
+ * @jest-environment node
+ */
+
+import { DELETE, GET, PATCH } from '@/app/api/skill/[id]/route';
+import { checkAuth } from '@/lib/check-auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    projectSkill: {
+      findFirst: jest.fn(),
+    },
+    skill: {
+      delete: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    userSkill: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+type MockRequest = {
+  json?: () => Promise<unknown>;
+  nextUrl: {
+    pathname: string;
+  };
+};
+
+const createRequest = (id = 'skill-1', body?: unknown) =>
+  ({
+    nextUrl: {
+      pathname: `/api/skill/${id}`,
+    },
+    json: body === undefined ? undefined : async () => body,
+  }) as MockRequest as NextRequest;
+
+const authorizeAdmin = () => {
+  (checkAuth as jest.Mock).mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: 'admin-1', role: 'ADMIN' },
+    },
+  });
+};
+
+describe('GET /api/skill/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve retornar skill pelo id', async () => {
+    const skill = {
+      id: 'skill-1',
+      name: 'React',
+      iconUrl: 'https://cdn.example.com/react.svg',
+    };
+
+    (prisma.skill.findUnique as jest.Mock).mockResolvedValue(skill);
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(skill);
+    expect(prisma.skill.findUnique).toHaveBeenCalledWith({
+      where: { id: 'skill-1' },
+    });
+  });
+
+  it('deve retornar 404 quando skill não existir', async () => {
+    (prisma.skill.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(createRequest('missing-skill'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+});
+
+describe('PATCH /api/skill/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve atualizar skill quando não houver conflito', async () => {
+    (prisma.skill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectSkill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.userSkill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.skill.update as jest.Mock).mockResolvedValue({
+      id: 'skill-1',
+      name: 'Vue',
+      iconUrl: 'https://cdn.example.com/vue.svg',
+    });
+
+    const response = await PATCH(
+      createRequest('skill-1', {
+        name: 'Vue',
+        iconUrl: 'https://cdn.example.com/vue.svg',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.name).toBe('Vue');
+    expect(prisma.skill.update).toHaveBeenCalledWith({
+      where: { id: 'skill-1' },
+      data: {
+        name: 'Vue',
+        iconUrl: 'https://cdn.example.com/vue.svg',
+      },
+    });
+  });
+
+  it('deve retornar 400 quando payload for inválido', async () => {
+    const response = await PATCH(
+      createRequest('skill-1', {
+        name: '',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.skill.update).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando nome já existir em outra skill', async () => {
+    (prisma.skill.findFirst as jest.Mock).mockResolvedValue({
+      id: 'skill-2',
+      name: 'React',
+    });
+
+    const response = await PATCH(
+      createRequest('skill-1', {
+        name: 'React',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.skill.update).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando skill estiver vinculada e forceUpdate não for enviado', async () => {
+    (prisma.skill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectSkill.findFirst as jest.Mock).mockResolvedValue({
+      id: 'project-skill-1',
+    });
+    (prisma.userSkill.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await PATCH(
+      createRequest('skill-1', {
+        name: 'React Native',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.skill.update).not.toHaveBeenCalled();
+  });
+
+  it('deve permitir atualização vinculada quando forceUpdate for true', async () => {
+    (prisma.skill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectSkill.findFirst as jest.Mock).mockResolvedValue({
+      id: 'project-skill-1',
+    });
+    (prisma.userSkill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.skill.update as jest.Mock).mockResolvedValue({
+      id: 'skill-1',
+      name: 'React Native',
+      iconUrl: undefined,
+    });
+
+    const response = await PATCH(
+      createRequest('skill-1', {
+        name: 'React Native',
+        forceUpdate: true,
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.name).toBe('React Native');
+    expect(prisma.skill.update).toHaveBeenCalledWith({
+      where: { id: 'skill-1' },
+      data: {
+        name: 'React Native',
+        iconUrl: undefined,
+      },
+    });
+  });
+});
+
+describe('DELETE /api/skill/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve deletar skill sem vínculos', async () => {
+    (prisma.userSkill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectSkill.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.skill.delete as jest.Mock).mockResolvedValue({
+      id: 'skill-1',
+    });
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(prisma.skill.delete).toHaveBeenCalledWith({
+      where: { id: 'skill-1' },
+    });
+  });
+
+  it('deve bloquear remoção quando skill estiver em uso', async () => {
+    (prisma.userSkill.findFirst as jest.Mock).mockResolvedValue({
+      id: 'user-skill-1',
+    });
+    (prisma.projectSkill.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.skill.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/api/skill/skill-route.test.ts
+++ b/src/tests/api/skill/skill-route.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET, POST } from '@/app/api/skill/route';
+import { GET as GET_COUNT } from '@/app/api/skill/count/route';
+import { checkAuth } from '@/lib/check-auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    skill: {
+      count: jest.fn(),
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+type MockRequest = {
+  json: () => Promise<unknown>;
+};
+
+const authorizeAdmin = () => {
+  (checkAuth as jest.Mock).mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: 'admin-1', role: 'ADMIN' },
+    },
+  });
+};
+
+describe('GET /api/skill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve listar skills em ordem alfabética', async () => {
+    const skills = [
+      {
+        id: 'skill-1',
+        name: 'React',
+        iconUrl: 'https://cdn.example.com/react.svg',
+      },
+    ];
+
+    (prisma.skill.findMany as jest.Mock).mockResolvedValue(skills);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(skills);
+    expect(prisma.skill.findMany).toHaveBeenCalledWith({
+      orderBy: { name: 'asc' },
+    });
+  });
+});
+
+describe('POST /api/skill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
+  });
+
+  it('deve criar skill quando nome for válido e não existir conflito', async () => {
+    (prisma.skill.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.skill.create as jest.Mock).mockResolvedValue({
+      id: 'skill-1',
+      name: 'React',
+      iconUrl:
+        'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg',
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'React',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data.name).toBe('React');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg'
+    );
+    expect(prisma.skill.create).toHaveBeenCalledWith({
+      data: {
+        name: 'React',
+        iconUrl:
+          'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg',
+      },
+    });
+  });
+
+  it('deve retornar 400 quando payload for inválido', async () => {
+    const request: MockRequest = {
+      json: async () => ({
+        name: '',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.skill.create).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 400 quando ícone não existir no Devicon', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as jest.Mock;
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'UnknownSkill',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.message).toBe('Ícone não encontrado no repositório Devicon.');
+    expect(prisma.skill.create).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando skill já existir', async () => {
+    (prisma.skill.findUnique as jest.Mock).mockResolvedValue({
+      id: 'skill-existing',
+      name: 'React',
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'React',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.skill.create).not.toHaveBeenCalled();
+  });
+
+  it('deve bloquear criação para usuário não autorizado', async () => {
+    const authResponse = Response.json(
+      { error: 'Acesso negado.' },
+      { status: 403 }
+    );
+
+    (checkAuth as jest.Mock).mockResolvedValue({
+      authorized: false,
+      response: authResponse,
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'React',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+
+    expect(response.status).toBe(403);
+    expect(prisma.skill.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/skill/count', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve retornar total de skills', async () => {
+    (prisma.skill.count as jest.Mock).mockResolvedValue(4);
+
+    const response = await GET_COUNT();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ count: 4 });
+    expect(prisma.skill.count).toHaveBeenCalledWith();
+  });
+});

--- a/src/tests/api/tech-stack/tech-stack-id-route.test.ts
+++ b/src/tests/api/tech-stack/tech-stack-id-route.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @jest-environment node
+ */
+
+import { DELETE, GET, PATCH } from '@/app/api/tech-stack/[id]/route';
+import { checkAuth } from '@/lib/check-auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    projectStack: {
+      findFirst: jest.fn(),
+    },
+    stack: {
+      delete: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+type MockRequest = {
+  json?: () => Promise<unknown>;
+  nextUrl: {
+    pathname: string;
+  };
+};
+
+const createRequest = (id = 'stack-1', body?: unknown) =>
+  ({
+    nextUrl: {
+      pathname: `/api/tech-stack/${id}`,
+    },
+    json: body === undefined ? undefined : async () => body,
+  }) as MockRequest as NextRequest;
+
+const authorizeAdmin = () => {
+  (checkAuth as jest.Mock).mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: 'admin-1', role: 'ADMIN' },
+    },
+  });
+};
+
+describe('GET /api/tech-stack/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve retornar stack pelo id', async () => {
+    const stack = {
+      id: 'stack-1',
+      name: 'Node.js',
+    };
+
+    (prisma.stack.findUnique as jest.Mock).mockResolvedValue(stack);
+
+    const response = await GET(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(stack);
+    expect(prisma.stack.findUnique).toHaveBeenCalledWith({
+      where: { id: 'stack-1' },
+    });
+  });
+
+  it('deve retornar 404 quando stack não existir', async () => {
+    (prisma.stack.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(createRequest('missing-stack'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+});
+
+describe('PATCH /api/tech-stack/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve atualizar stack quando não houver conflito', async () => {
+    (prisma.stack.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectStack.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.stack.update as jest.Mock).mockResolvedValue({
+      id: 'stack-1',
+      name: 'NestJS',
+    });
+
+    const response = await PATCH(
+      createRequest('stack-1', {
+        name: 'NestJS',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.name).toBe('NestJS');
+    expect(prisma.stack.update).toHaveBeenCalledWith({
+      where: { id: 'stack-1' },
+      data: { name: 'NestJS' },
+    });
+  });
+
+  it('deve retornar 400 quando payload for inválido', async () => {
+    const response = await PATCH(
+      createRequest('stack-1', {
+        name: '',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.stack.update).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando nome já existir em outra stack', async () => {
+    (prisma.stack.findFirst as jest.Mock).mockResolvedValue({
+      id: 'stack-2',
+      name: 'Node.js',
+    });
+
+    const response = await PATCH(
+      createRequest('stack-1', {
+        name: 'Node.js',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.stack.update).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando stack estiver vinculada e forceUpdate não for enviado', async () => {
+    (prisma.stack.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectStack.findFirst as jest.Mock).mockResolvedValue({
+      id: 'project-stack-1',
+    });
+
+    const response = await PATCH(
+      createRequest('stack-1', {
+        name: 'Node.js',
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.stack.update).not.toHaveBeenCalled();
+  });
+
+  it('deve permitir atualização vinculada quando forceUpdate for true', async () => {
+    (prisma.stack.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.projectStack.findFirst as jest.Mock).mockResolvedValue({
+      id: 'project-stack-1',
+    });
+    (prisma.stack.update as jest.Mock).mockResolvedValue({
+      id: 'stack-1',
+      name: 'Node.js',
+    });
+
+    const response = await PATCH(
+      createRequest('stack-1', {
+        name: 'Node.js',
+        forceUpdate: true,
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.name).toBe('Node.js');
+    expect(prisma.stack.update).toHaveBeenCalledWith({
+      where: { id: 'stack-1' },
+      data: { name: 'Node.js' },
+    });
+  });
+});
+
+describe('DELETE /api/tech-stack/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve deletar stack sem vínculos', async () => {
+    (prisma.projectStack.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.stack.delete as jest.Mock).mockResolvedValue({
+      id: 'stack-1',
+    });
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({ deletedId: 'stack-1' });
+    expect(prisma.stack.delete).toHaveBeenCalledWith({
+      where: { id: 'stack-1' },
+    });
+  });
+
+  it('deve bloquear remoção quando stack estiver vinculada a projeto', async () => {
+    (prisma.projectStack.findFirst as jest.Mock).mockResolvedValue({
+      id: 'project-stack-1',
+    });
+
+    const response = await DELETE(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.stack.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/api/tech-stack/tech-stack-route.test.ts
+++ b/src/tests/api/tech-stack/tech-stack-route.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET, POST } from '@/app/api/tech-stack/route';
+import { GET as GET_COUNT } from '@/app/api/tech-stack/count/route';
+import { checkAuth } from '@/lib/check-auth';
+import { prisma } from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    stack: {
+      count: jest.fn(),
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/check-auth', () => ({
+  checkAuth: jest.fn(),
+}));
+
+type MockRequest = {
+  json: () => Promise<unknown>;
+};
+
+const authorizeAdmin = () => {
+  (checkAuth as jest.Mock).mockResolvedValue({
+    authorized: true,
+    session: {
+      user: { id: 'admin-1', role: 'ADMIN' },
+    },
+  });
+};
+
+describe('GET /api/tech-stack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve listar stacks em ordem alfabética', async () => {
+    const stacks = [
+      {
+        id: 'stack-1',
+        name: 'Node.js',
+      },
+    ];
+
+    (prisma.stack.findMany as jest.Mock).mockResolvedValue(stacks);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(stacks);
+    expect(prisma.stack.findMany).toHaveBeenCalledWith({
+      orderBy: { name: 'asc' },
+    });
+  });
+});
+
+describe('POST /api/tech-stack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authorizeAdmin();
+  });
+
+  it('deve criar stack quando nome for válido e não existir conflito', async () => {
+    (prisma.stack.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.stack.create as jest.Mock).mockResolvedValue({
+      id: 'stack-1',
+      name: 'Node.js',
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'Node.js',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({
+      id: 'stack-1',
+      name: 'Node.js',
+    });
+    expect(prisma.stack.create).toHaveBeenCalledWith({
+      data: { name: 'Node.js' },
+    });
+  });
+
+  it('deve retornar 400 quando payload for inválido', async () => {
+    const request: MockRequest = {
+      json: async () => ({
+        name: '',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(prisma.stack.create).not.toHaveBeenCalled();
+  });
+
+  it('deve retornar 409 quando stack já existir', async () => {
+    (prisma.stack.findUnique as jest.Mock).mockResolvedValue({
+      id: 'stack-existing',
+      name: 'Node.js',
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'Node.js',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(prisma.stack.create).not.toHaveBeenCalled();
+  });
+
+  it('deve bloquear criação para usuário não autorizado', async () => {
+    const authResponse = Response.json(
+      { error: 'Acesso negado.' },
+      { status: 403 }
+    );
+
+    (checkAuth as jest.Mock).mockResolvedValue({
+      authorized: false,
+      response: authResponse,
+    });
+
+    const request: MockRequest = {
+      json: async () => ({
+        name: 'Node.js',
+      }),
+    };
+
+    const response = await POST(request as NextRequest);
+
+    expect(response.status).toBe(403);
+    expect(prisma.stack.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/tech-stack/count', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve retornar total de stacks', async () => {
+    (prisma.stack.count as jest.Mock).mockResolvedValue(5);
+
+    const response = await GET_COUNT();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ count: 5 });
+    expect(prisma.stack.count).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
## Summary

- Added unit tests for Skill API routes.
- Added unit tests for TechStack API routes.
- Covered list, create, count, get by id, update, delete, duplicate name conflicts, linked record conflicts, invalid payloads, and unauthorized admin actions.
- Mocked Prisma, auth, and Devicon fetch to keep tests isolated.

## Validation

- `npm run test -- src/tests/api/skill src/tests/api/tech-stack`
- `npm run lint`
- `npm run test:push`
- `npx jest --coverage --coverageThreshold='{"global":{"branches":60,"functions":60,"lines":60,"statements":60}}'`
- `git diff --check`
- `npm run build`

Closes #534